### PR TITLE
Ignore temp files for vim and cscope/ctags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 out/
+*.swp
+cscope.*
+tags


### PR DESCRIPTION
Ignore some temp files otherwise we'll commit them in accident. 
