### PR TITLE
Remove the usage of XWALK_SOURCE_DIR and xwalk_path.

### DIFF
--- a/configure
+++ b/configure
@@ -3,14 +3,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-if [ ! -e $XWALK_SOURCE_DIR/xwalk.gyp ]; then
-   echo "Please set XWALK_SOURCE_DIR to the directory containing xwalk.gyp."
-   exit 1
-fi
-
 if [ ! `which gyp` ]; then
    echo -e "\nPlease make sure gyp is in your PATH. It is usually found at CHROMIUM_SRC/tools/gyp."
    exit 1
 fi
 
-gyp -D build=Debug -D type=desktop -D xwalk_path=$XWALK_SOURCE_DIR --depth=. tizen-wrt.gyp
+if [ ! `which xwalk` ]; then
+   echo -e "\nPlease make sure xwalk is in your PATH. It is usually found at XWALK_SOURCE_DIR/../out/Release/"
+    exit 1
+fi
+
+gyp -D build=Debug -D type=desktop --depth=. tizen-wrt.gyp

--- a/run.sh
+++ b/run.sh
@@ -3,9 +3,4 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-if [ ! -e $XWALK_SOURCE_DIR/xwalk.gyp ]; then
-   echo "Please set XWALK_SOURCE_DIR to the directory containing xwalk.gyp."
-   exit 1
-fi
-
-exec $XWALK_SOURCE_DIR/../out/Release/xwalk --external-extensions-path=$PWD/out/Default $PWD/examples/index.html
+exec xwalk --external-extensions-path=$PWD/out/Default $PWD/examples/index.html

--- a/tizen-wrt.gyp
+++ b/tizen-wrt.gyp
@@ -28,7 +28,6 @@
     ],
     'include_dirs': [
       '.',
-      '<(xwalk_path)/extensions/public',
     ],
     'sources': [
       '../common/extension_adapter.h',

--- a/tools/generate_api.py
+++ b/tools/generate_api.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import sys
+
+TEMPLATE = """\
+extern const char %s[];
+const char %s[] = { %s, 0 };
+"""
+
+js_code = sys.argv[1]
+lines = file(js_code).read()
+c_code = ', '.join(str(ord(c)) for c in lines)
+
+symbol_name = sys.argv[2]
+output = open(sys.argv[3], "w")
+output.write(TEMPLATE % (symbol_name, symbol_name, c_code))
+output.close()

--- a/xwalk_extension_public.h
+++ b/xwalk_extension_public.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_PUBLIC_XWALK_EXTENSION_PUBLIC_H_
+#define XWALK_EXTENSIONS_PUBLIC_XWALK_EXTENSION_PUBLIC_H_
+
+#ifndef INTERNAL_IMPLEMENTATION
+#include <assert.h>
+#endif  // INTERNAL_IMPLEMENTATION
+
+#include <stdint.h>
+
+typedef struct CXWalkExtension_           CXWalkExtension;
+typedef struct CXWalkExtensionContext_    CXWalkExtensionContext;
+typedef struct CXWalkExtensionContextAPI_ CXWalkExtensionContextAPI;
+
+typedef void (*ExtensionShutdownCallback)(CXWalkExtension* extension);
+typedef const char* (*ExtensionGetJavaScriptCallback)(
+      CXWalkExtension* extension);
+typedef CXWalkExtensionContext* (*ExtensionContextCreateCallback)(
+      CXWalkExtension* extension);
+
+typedef void (*ExtensionContextDestroyCallback)(
+      CXWalkExtensionContext* context);
+typedef void (*ExtensionContextHandleMessageCallback)(
+      CXWalkExtensionContext* context, const char* message);
+
+typedef void (*ExtensionContextPostMessageCallback)(
+      CXWalkExtensionContext* context, const char* message);
+
+struct CXWalkExtension_ {
+  int32_t api_version;
+
+  // Version 1
+  const char* name;
+
+  ExtensionGetJavaScriptCallback get_javascript;
+  ExtensionShutdownCallback shutdown;
+  ExtensionContextCreateCallback context_create;
+};
+
+struct CXWalkExtensionContextAPI_ {
+  // Version 1
+  ExtensionContextPostMessageCallback post_message;
+};
+
+struct CXWalkExtensionContext_ {
+  void* internal_data;
+  const CXWalkExtensionContextAPI* api;
+
+  // Version 1
+  ExtensionContextDestroyCallback destroy;
+  ExtensionContextHandleMessageCallback handle_message;
+};
+
+#ifndef INTERNAL_IMPLEMENTATION
+// This function should be implemented and exported in the shared
+// object. The ``api_version'' parameter will contain the maximum
+// version supported by Crosswalk.
+// On a successful invocation, this function should return a pointer
+// to a CXWalkExtension structure, with the fields:
+// - api_version, filled with the API version the extension implements.
+// - name, with the extension name (used by xwalk.postMessage() and
+//   friends).
+// - get_javascript, filled with a pointer to a function that returns
+//   the JavaScript shim to be available in all page contexts.
+// - shutdown, filled with a pointer to a function that is called
+//   whenever this extension is shut down (e.g. Crosswalk terminating). NULL
+//   is fine.
+// - context_create, filled with a pointer to a function that creates
+//   an extension context (see comment below).
+
+#if defined(_WIN32)
+#define PUBLIC_EXPORT __declspec(dllexport)
+#else
+#define PUBLIC_EXPORT __attribute__((visibility("default")))
+#endif
+
+#if defined(__cplusplus)
+#define EXTERN_C extern "C"
+#else
+#define EXTERN_C
+#endif
+
+EXTERN_C PUBLIC_EXPORT CXWalkExtension* xwalk_extension_init(
+      int32_t api_version);
+
+// A CXWalkExtension structure holds the global state for a extension.
+// Due to the multithreaded way Crosswalk is written, one should not
+// store mutable state there. That's the reason CXWalkExtensionContext
+// exists: so each page context has its own state and there's no need
+// to worry about race conditions while keeping state between contexts.
+//
+// The first two fields of a context (internal_data and api) should not
+// be tampered with. The following fields, though, should be filled:
+// - destroy, with a pointer to a function that will be called whenever
+//   a particular context is about to be destroyed.
+// - handle_message, with a pointer to a function that will be called
+//   whenever a message arrives from the JavaScript side.
+//
+// To post a message to the JavaScript side, one can simply call
+// xwalk_extension_context_post_message(), defined below. Crosswalk will
+// handle all the multithreading details so it is safe to call this
+// whenever necessary.
+static void xwalk_extension_context_post_message(
+      CXWalkExtensionContext* context, const char* message) {
+  assert(context);
+  assert(context->api);
+  assert(context->api->post_message);
+  assert(message);
+
+  context->api->post_message(context, message);
+}
+
+#undef PUBLIC_EXPORT
+#undef EXTERN_C
+
+#endif  // INTERNAL_IMPLEMENTATION
+
+#endif  // XWALK_EXTENSIONS_PUBLIC_XWALK_EXTENSION_PUBLIC_H_

--- a/xwalk_js2c.gypi
+++ b/xwalk_js2c.gypi
@@ -4,7 +4,7 @@
       'rule_name': 'xwalk_js2c',
       'extension': 'js',
       'inputs': [
-        '<(xwalk_path)/extensions/tools/generate_api.py',
+        './tools/generate_api.py',
       ],
       'outputs': [
         '<(SHARED_INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).cc'


### PR DESCRIPTION
This puts everything you need to build the extensions on its own source directory,
so there is no need to export XWALK_SOURCE_DIR in order to build it.

For calling run.sh, though, you will need to have 'xwalk' binary on your $PATH.
