### PR TITLE
Move the check for xwalk from configure to run.sh.

### DIFF
--- a/configure
+++ b/configure
@@ -8,9 +8,4 @@ if [ ! `which gyp` ]; then
    exit 1
 fi
 
-if [ ! `which xwalk` ]; then
-   echo -e "\nPlease make sure xwalk is in your PATH. It is usually found at XWALK_SOURCE_DIR/../out/Release/"
-    exit 1
-fi
-
 gyp -D build=Debug -D type=desktop --depth=. tizen-wrt.gyp

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+if [ ! `which xwalk` ]; then
+   echo -e "\nPlease make sure xwalk is in your PATH. It is usually found at XWALK_SOURCE_DIR/../out/Release/"
+   exit 1
+fi
+
 exec xwalk "$@" --external-extensions-path=$PWD/out/Default $PWD/examples/index.html


### PR DESCRIPTION
Crosswalk is a run-time dependency for tizen-extensions-crosswalk, so it is 
fine if the xwalk binary is not found at build-time.

It is a real problem if it cannot be found when we need to run it, though.
