### PR TITLE
Disable the notifications and power extensions for mobile.

### DIFF
--- a/configure
+++ b/configure
@@ -8,4 +8,4 @@ if [ ! `which gyp` ]; then
    exit 1
 fi
 
-gyp -D build=Debug -D type=desktop --depth=. tizen-wrt.gyp
+gyp -D build=Debug -D type=mobile --depth=. tizen-wrt.gyp

--- a/tizen-wrt.gyp
+++ b/tizen-wrt.gyp
@@ -39,9 +39,17 @@
     ],
   },
 
+  # TODO: These modules still do not build properly with the mobile profile,
+  #       so only enable them when building their desktop versions.
+  'conditions': [
+    ['type == "desktop"', {
+      'includes': {
+        'notification/notification.gypi',
+        'power/power.gypi'
+      }
+    }]
+   ],
   'includes': {
-    'notification/notification.gypi',
     'time/time.gypi',
-    'power/power.gypi',
   },
 }


### PR DESCRIPTION
notifications does not currently build, and power has missing symbols at 
run-time.

Explicitly disable them when not building with type=="desktop" so that 
packaging for Tizen does not break.
