### PR TITLE
Make sure the Tizen Power API works on Tizen 2.1

### DIFF
--- a/examples/power.html
+++ b/examples/power.html
@@ -92,20 +92,27 @@ function ScreenStateChangeListener(prevState, newState) {
   changedState = newState;
 }
 tizen.power.setScreenStateChangeListener(ScreenStateChangeListener);
-tizen.power.request('SCREEN', 'SCREEN_NORMAL');
+tizen.power.request('SCREEN', 'SCREEN_DIM');
+setTimeout(waitForListener, 100);
 
-setTimeout(finish, 100);
-
-function finish() {
+function waitForListener() {
   // ScreenStateChangeListener will be called asynchronously, so we check it a bit later.
-  shouldBe("previousState", "'SCREEN_BRIGHT'");
-  shouldBe("changedState", "'SCREEN_NORMAL'");
+  shouldBe("previousState", "'SCREEN_NORMAL'");
+  shouldBe("changedState", "'SCREEN_DIM'");
+  shouldBeTrue("tizen.power.isScreenOn()");
+  shouldNotThrow("tizen.power.turnScreenOff()");
+  setTimeout(waitForScreenOff, 100);
+}
 
-  shouldThrow("tizen.power.release(1)", "new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR)")
+function waitForScreenOff() {
+  shouldBeFalse("tizen.power.isScreenOn()");
+  shouldNotThrow("tizen.power.turnScreenOn()");
+  shouldThrow("tizen.power.release(1)", "new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR)");
   shouldThrow("tizen.power.release('MOUSE')", "new tizen.WebAPIException(tizen.WebAPIException.INVALID_VALUES_ERR)");
   shouldNotThrow("tizen.power.release('CPU')");
   shouldNotThrow("tizen.power.release('SCREEN')");
 }
+
 </script>
 </body>
 </html>

--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -10,6 +10,10 @@ Source1:    %{name}
 Source1001: %{name}.manifest
 
 BuildRequires: python
+BuildRequires: pkgconfig(capi-system-device)
+BuildRequires: pkgconfig(capi-system-power)
+BuildRequires: pkgconfig(pmapi)
+BuildRequires: pkgconfig(vconf)
 Requires:      crosswalk
 
 %description

--- a/power/power.gypi
+++ b/power/power.gypi
@@ -8,6 +8,101 @@
         'power_context.cc',
         'power_context.h',
         'power_context_desktop.cc',
+        'power_context_mobile.cc',
+      ],
+      'dependencies': [
+        'capi-system-device',
+        'capi-system-power',
+        'pmapi',
+        'vconf',
+      ],
+    },
+
+    {
+      'target_name': 'vconf',
+      'type': 'none',
+      'conditions': [
+        ['type=="mobile"', {
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags vconf)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(pkg-config --libs-only-L --libs-only-other vconf)',
+            ],
+            'libraries': [
+              '<!@(pkg-config --libs-only-l vconf)',
+            ],
+          }
+        }],
+      ],
+    },
+
+    {
+      'target_name': 'capi-system-power',
+      'type': 'none',
+      'conditions': [
+        ['type=="mobile"', {
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags capi-system-power)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(pkg-config --libs-only-L --libs-only-other capi-system-power)',
+            ],
+            'libraries': [
+              '<!@(pkg-config --libs-only-l capi-system-power)',
+            ],
+          }
+        }],
+      ],
+    },
+
+    {
+      'target_name': 'capi-system-device',
+      'type': 'none',
+      'conditions': [
+        ['type=="mobile"', {
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags capi-system-device)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(pkg-config --libs-only-L --libs-only-other capi-system-device)',
+            ],
+            'libraries': [
+              '<!@(pkg-config --libs-only-l capi-system-device)',
+            ],
+          }
+        }],
+      ],
+    },
+
+    {
+      'target_name': 'pmapi',
+      'type': 'none',
+      'conditions': [
+        ['type=="mobile"', {
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(pkg-config --cflags pmapi)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(pkg-config --libs-only-L --libs-only-other pmapi)',
+            ],
+            'libraries': [
+              '<!@(pkg-config --libs-only-l pmapi)',
+            ],
+          }
+        }],
       ],
 
       'conditions': [
@@ -18,5 +113,6 @@
         ],
       ],
     },
+
   ],
 }

--- a/power/power_api.js
+++ b/power/power_api.js
@@ -43,13 +43,23 @@ var sendSyncMessage = function(msg) {
   return extension.internal.sendSyncMessage(JSON.stringify(msg));
 };
 
+function getScreenState() {
+  if (screenState === undefined) {
+    var msg = {
+      'cmd': 'PowerGetScreenState'
+    };
+    var r = JSON.parse(sendSyncMessage(msg));
+    screenState = r.state;
+  }
+}
+
 extension.setMessageListener(function(msg) {
   var m = JSON.parse(msg);
   if (m.cmd == "ScreenStateChanged") {
-    var newState = parseInt(m.state);
-    if (screenState == undefined || screenState !== newState) {
+    var newState = m.state;
+    if (screenState !== newState) {
       if (screenState == undefined) {
-        screenState = 0; // "SCREEN_OFF"
+        screenState = resources["SCREEN"].states["SCREEN_OFF"];
       }
       callListeners(screenState, newState);
       screenState = newState;
@@ -143,7 +153,8 @@ exports.setScreenBrightness = function(brightness) {
 }
 
 exports.isScreenOn = function() {
-   if (typeof screenState !== 'number')
+  getScreenState();
+  if (typeof screenState !== 'number')
     throw new tizen.WebAPIException(tizen.WebAPIException.UNKNOWN_ERR);
   return screenState !== resources["SCREEN"].states["SCREEN_OFF"]
 }
@@ -168,7 +179,7 @@ exports.turnScreenOff = function() {
   // FIXME: throw UNKNOWN_ERR during failure to set the new value.
   postMessage({
     "cmd": "PowerSetScreenEnabled",
-    "value": true
+    "value": false
   });
 }
 

--- a/power/power_context.cc
+++ b/power/power_context.cc
@@ -65,6 +65,8 @@ void PowerContext::HandleSyncMessage(const char* message) {
   std::string cmd = v.get("cmd").to_str();
   if (cmd == "PowerGetScreenBrightness") {
     HandleGetScreenBrightness();
+  }  else if (cmd == "PowerGetScreenState") {
+    HandleGetScreenState();
   } else {
     std::cout << "ASSERT NOT REACHED.\n";
   }

--- a/power/power_context.h
+++ b/power/power_context.h
@@ -31,7 +31,6 @@ class PowerContext {
   void HandleMessage(const char* message);
   void HandleSyncMessage(const char* message);
 
- private:
   // These enums must be kept in sync with the JS object notation.
   enum ResourceType {
     SCREEN = 0,
@@ -49,11 +48,14 @@ class PowerContext {
   };
 
   void OnScreenStateChanged(ResourceState state);
+
+private:
   void HandleRequest(const picojson::value& msg);
   void HandleRelease(const picojson::value& msg);
   void HandleSetScreenBrightness(const picojson::value& msg);
   void HandleGetScreenBrightness();
   void HandleSetScreenEnabled(const picojson::value& msg);
+  void HandleGetScreenState();
 
   ContextAPI* api_;
 

--- a/tizen-wrt.gyp
+++ b/tizen-wrt.gyp
@@ -45,11 +45,11 @@
     ['type == "desktop"', {
       'includes': {
         'notification/notification.gypi',
-        'power/power.gypi'
       }
     }]
    ],
   'includes': {
+    'power/power.gypi',
     'tizen/tizen.gypi',
     'time/time.gypi',
     'bluetooth/bluetooth.gypi'


### PR DESCRIPTION
Unfortunately some of the tests are not passing because the underlaying
C API does not function correctly on the device (e.g. querying the max
brightness, setting the brightness or the power state).

Exceptions are also not yet propataged from C++ to JS.
