### PR TITLE
[Power] Add HandleGetScreenState() to avoid undefined reference on desktop

### DIFF
--- a/power/power_context_desktop.cc
+++ b/power/power_context_desktop.cc
@@ -118,3 +118,10 @@ void PowerContext::HandleGetScreenBrightness() {
 void PowerContext::HandleSetScreenEnabled(const picojson::value& msg) {
   bool isEnabled = msg.get("value").get<bool>();
 }
+
+void PowerContext::HandleGetScreenState() {
+  picojson::value::object o;
+  o["state"] = picojson::value(static_cast<double>(PowerContext::SCREEN_NORMAL));
+  picojson::value v(o);
+  api_->SetSyncReply(v.serialize().c_str());
+}


### PR DESCRIPTION
Add HandleGetScreenState() to avoid undefined reference on desktop.
This function doesn't do anything on desktop. It just return screen state
as normal always.
