### PR TITLE
Remove --fullscreen from tizen-extensions-crosswalk script.

### DIFF
--- a/packaging/tizen-extensions-crosswalk
+++ b/packaging/tizen-extensions-crosswalk
@@ -5,4 +5,4 @@ if [ ! -f /usr/bin/xwalk ]; then
    exit 1
 fi
 
-exec /usr/bin/xwalk --allow-external-extensions-for-remote-sources --fullscreen --external-extensions-path=/usr/lib/tizen-extensions-crosswalk "$@"
+exec /usr/bin/xwalk --allow-external-extensions-for-remote-sources --external-extensions-path=/usr/lib/tizen-extensions-crosswalk "$@"


### PR DESCRIPTION
We don't need to call --fullscreen, Xwalk can figure out by itself
that it should run in fullscreen or not as we integrate with the
window manager.
