### PR TITLE
Value of WebAPIException should be number

### DIFF
--- a/tizen/tizen_api.js
+++ b/tizen/tizen_api.js
@@ -72,7 +72,7 @@ exports.WebAPIException = function (code, message, name) {
 }
 
 for (var value in errors)
-  Object.defineProperty(tizen.WebAPIException, errors[value].type, { value: value });
+  Object.defineProperty(tizen.WebAPIException, errors[value].type, { value: parseInt(value) });
 
 exports.WebAPIError = function (code, message, name) {
   var _code, _message, _name;


### PR DESCRIPTION
`tizen.WebAPIException.TYPE_MISMATCH_ERR` should be number, as the WebAPIException is constructed by number.
