### PR TITLE
[SystemInfo] Force cpplint to ignore const reference warning

### DIFF
--- a/system_info/system_info_battery.h
+++ b/system_info/system_info_battery.h
@@ -22,13 +22,13 @@ class SysInfoBattery {
  public:
   explicit SysInfoBattery(ContextAPI* api);
   ~SysInfoBattery();
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   void StartListening();
   void StopListening();
 
  private:
-  bool Update(picojson::value& error);
-  void SetData(picojson::value& data);
+  bool Update(picojson::value& error); //NOLINT
+  void SetData(picojson::value& data); //NOLINT
 
 #if defined(GENERIC_DESKTOP)
   static gboolean OnUpdateTimeout(gpointer user_data);

--- a/system_info/system_info_battery_desktop.cc
+++ b/system_info/system_info_battery_desktop.cc
@@ -36,7 +36,7 @@ void SysInfoBattery::StopListening() {
     g_source_remove(timeout_cb_id_);
 }
 
-void SysInfoBattery::Get(picojson::value& error,
+void SysInfoBattery::Get(picojson::value& error, //NOLINT
                          picojson::value& data) {
   if (!Update(error)) {
     system_info::SetPicoJsonObjectValue(error, "message",
@@ -48,7 +48,7 @@ void SysInfoBattery::Get(picojson::value& error,
   system_info::SetPicoJsonObjectValue(error, "message", picojson::value(""));
 }
 
-bool SysInfoBattery::Update(picojson::value& error) {
+bool SysInfoBattery::Update(picojson::value& error) { //NOLINT
   bool found;
   struct udev_enumerate *enumerate;
   struct udev_list_entry *devices, *dev_list_entry;
@@ -122,7 +122,7 @@ gboolean SysInfoBattery::OnUpdateTimeout(gpointer user_data) {
   return TRUE;
 }
 
-void SysInfoBattery::SetData(picojson::value& data) {
+void SysInfoBattery::SetData(picojson::value& data) { //NOLINT
   system_info::SetPicoJsonObjectValue(data, "level",
       picojson::value(level_));
   system_info::SetPicoJsonObjectValue(data, "isCharging",

--- a/system_info/system_info_battery_mobile.cc
+++ b/system_info/system_info_battery_mobile.cc
@@ -21,7 +21,7 @@ SysInfoBattery::~SysInfoBattery() {
     StopListening();
 }
 
-void SysInfoBattery::Get(picojson::value& error,
+void SysInfoBattery::Get(picojson::value& error, //NOLINT
                          picojson::value& data) {
   int level = 0;
   int charging = 0;
@@ -40,7 +40,7 @@ void SysInfoBattery::Get(picojson::value& error,
   system_info::SetPicoJsonObjectValue(error, "message", picojson::value(""));
 }
 
-bool SysInfoBattery::Update(picojson::value& error) {
+bool SysInfoBattery::Update(picojson::value& error) { //NOLINT
   picojson::value output = picojson::value(picojson::object());
   picojson::value data = picojson::value(picojson::object());
 
@@ -56,7 +56,7 @@ bool SysInfoBattery::Update(picojson::value& error) {
   return true;
 }
 
-void SysInfoBattery::SetData(picojson::value& data) {
+void SysInfoBattery::SetData(picojson::value& data) { //NOLINT
   system_info::SetPicoJsonObjectValue(data, "level",
       picojson::value(level_));
   system_info::SetPicoJsonObjectValue(data, "isCharging",

--- a/system_info/system_info_build.h
+++ b/system_info/system_info_build.h
@@ -17,7 +17,7 @@ class SysInfoBuild {
  public:
   explicit SysInfoBuild(ContextAPI* api);
   ~SysInfoBuild();
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   inline void StartListening() {
     timeout_cb_id_ = g_timeout_add(system_info::default_timeout_interval,
                                    SysInfoBuild::OnUpdateTimeout,

--- a/system_info/system_info_build_desktop.cc
+++ b/system_info/system_info_build_desktop.cc
@@ -22,7 +22,7 @@ SysInfoBuild::SysInfoBuild(ContextAPI* api)
 SysInfoBuild::~SysInfoBuild() {
 }
 
-void SysInfoBuild::Get(picojson::value& error,
+void SysInfoBuild::Get(picojson::value& error, //NOLINT
                        picojson::value& data) {
   // model and manufacturer
   if (!UpdateHardware()) {

--- a/system_info/system_info_build_mobile.cc
+++ b/system_info/system_info_build_mobile.cc
@@ -22,7 +22,7 @@ SysInfoBuild::~SysInfoBuild() {
       g_source_remove(timeout_cb_id_);
 }
 
-void SysInfoBuild::Get(picojson::value& error,
+void SysInfoBuild::Get(picojson::value& error, //NOLINT
                        picojson::value& data) {
   // model and manufacturer
   if (!UpdateHardware()) {

--- a/system_info/system_info_cellular_network.h
+++ b/system_info/system_info_cellular_network.h
@@ -26,14 +26,14 @@ class SysInfoCellularNetwork {
   if (isRegister_)
     StopListening();
 }
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   void StartListening();
   void StopListening();
 
  private:
 #if defined(TIZEN_MOBILE)
   void SendUpdate();
-  void SetData(picojson::value& data);
+  void SetData(picojson::value& data); //NOLINT
 
   void SetCellStatus();
   void SetAPN();

--- a/system_info/system_info_cellular_network_desktop.cc
+++ b/system_info/system_info_cellular_network_desktop.cc
@@ -6,7 +6,7 @@
 
 #include "system_info/system_info_utils.h"
 
-void SysInfoCellularNetwork::Get(picojson::value& error,
+void SysInfoCellularNetwork::Get(picojson::value& error, //NOLINT
                                  picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Cellular Network is not supported on desktop."));

--- a/system_info/system_info_cellular_network_mobile.cc
+++ b/system_info/system_info_cellular_network_mobile.cc
@@ -124,7 +124,7 @@ void SysInfoCellularNetwork::SetIMEI() {
   free(imei);
 }
 
-void SysInfoCellularNetwork::Get(picojson::value& error,
+void SysInfoCellularNetwork::Get(picojson::value& error, //NOLINT
                                  picojson::value& data) {
   SetCellStatus();
   SetAPN();
@@ -140,7 +140,7 @@ void SysInfoCellularNetwork::Get(picojson::value& error,
   system_info::SetPicoJsonObjectValue(error, "message", picojson::value(""));
 }
 
-void SysInfoCellularNetwork::SetData(picojson::value& data) {
+void SysInfoCellularNetwork::SetData(picojson::value& data) { //NOLINT
   system_info::SetPicoJsonObjectValue(data, "status",
         picojson::value(status_));
   system_info::SetPicoJsonObjectValue(data, "apn",

--- a/system_info/system_info_context.h
+++ b/system_info/system_info_context.h
@@ -41,7 +41,7 @@ class SystemInfoContext {
   void HandleStartListening(const picojson::value& input);
   void HandleStopListening(const picojson::value& input);
   void HandleGetCapabilities();
-  inline void SetStringPropertyValue(picojson::object& o,
+  inline void SetStringPropertyValue(picojson::object& o, //NOLINT
                                      const char* prop,
                                      const char* val) {
     if (val)

--- a/system_info/system_info_cpu.cc
+++ b/system_info/system_info_cpu.cc
@@ -9,7 +9,7 @@
 
 #include "system_info/system_info_utils.h"
 
-void SysInfoCpu::Get(picojson::value& error,
+void SysInfoCpu::Get(picojson::value& error, //NOLINT
                      picojson::value& data) {
   if (!UpdateLoad()) {
     system_info::SetPicoJsonObjectValue(error, "message",

--- a/system_info/system_info_cpu.h
+++ b/system_info/system_info_cpu.h
@@ -24,7 +24,7 @@ class SysInfoCpu {
       g_source_remove(timeout_cb_id_);
 }
   // Get support
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
 
   // Listerner support
   inline void StartListening() {

--- a/system_info/system_info_device_orientation.h
+++ b/system_info/system_info_device_orientation.h
@@ -37,7 +37,7 @@ class SysInfoDeviceOrientation {
     StopListening();
   }
 }
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   void StartListening();
   void StopListening();
 
@@ -46,7 +46,7 @@ class SysInfoDeviceOrientation {
   void SetStatus();
   bool SetAutoRotation();
   void SendUpdate();
-  void SetData(picojson::value& data);
+  void SetData(picojson::value& data); //NOLINT
   std::string ToOrientationStatusString
       (SystemInfoDeviceOrientationStatus status);
   enum SystemInfoDeviceOrientationStatus EventToStatus(int event_data);

--- a/system_info/system_info_device_orientation_desktop.cc
+++ b/system_info/system_info_device_orientation_desktop.cc
@@ -6,7 +6,7 @@
 
 #include "system_info/system_info_utils.h"
 
-void SysInfoDeviceOrientation::Get(picojson::value& error,
+void SysInfoDeviceOrientation::Get(picojson::value& error, //NOLINT
                                    picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Device Orientation is not supported on desktop."));

--- a/system_info/system_info_device_orientation_mobile.cc
+++ b/system_info/system_info_device_orientation_mobile.cc
@@ -6,7 +6,7 @@
 
 #include "system_info/system_info_utils.h"
 
-void SysInfoDeviceOrientation::Get(picojson::value& error,
+void SysInfoDeviceOrientation::Get(picojson::value& error, //NOLINT
                                    picojson::value& data) {
   SetStatus();
   if (!SetAutoRotation()) {
@@ -39,7 +39,7 @@ bool SysInfoDeviceOrientation::SetAutoRotation() {
   return true;
 }
 
-void SysInfoDeviceOrientation::SetData(picojson::value& data) {
+void SysInfoDeviceOrientation::SetData(picojson::value& data) { //NOLINT
   system_info::SetPicoJsonObjectValue(data, "status",
       picojson::value(ToOrientationStatusString(status_)));
   system_info::SetPicoJsonObjectValue(data, "isAutoRotation",

--- a/system_info/system_info_display.h
+++ b/system_info/system_info_display.h
@@ -20,7 +20,7 @@ class SysInfoDisplay {
       g_source_remove(timeout_cb_id_);
 }
   // Get support
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   // Listerner support
   inline void StartListening() {
     // FIXME(halton): Use Xlib event or D-Bus interface to monitor.
@@ -37,7 +37,7 @@ class SysInfoDisplay {
   static gboolean OnUpdateTimeout(gpointer user_data);
   bool UpdateSize();
   bool UpdateBrightness();
-  void SetData(picojson::value& data);
+  void SetData(picojson::value& data); //NOLINT
 
   ContextAPI* api_;
   int resolution_width_;

--- a/system_info/system_info_display_x11.cc
+++ b/system_info/system_info_display_x11.cc
@@ -29,7 +29,7 @@ SysInfoDisplay::SysInfoDisplay(ContextAPI* api)
   api_ = api;
 }
 
-void SysInfoDisplay::Get(picojson::value& error,
+void SysInfoDisplay::Get(picojson::value& error, //NOLINT
                          picojson::value& data) {
   if (!UpdateSize()) {
     system_info::SetPicoJsonObjectValue(error, "message",
@@ -128,7 +128,7 @@ gboolean SysInfoDisplay::OnUpdateTimeout(gpointer user_data) {
   return TRUE;
 }
 
-void SysInfoDisplay::SetData(picojson::value& data) {
+void SysInfoDisplay::SetData(picojson::value& data) { //NOLINT
   system_info::SetPicoJsonObjectValue(data, "brightness",
       picojson::value(brightness_));
 

--- a/system_info/system_info_locale.h
+++ b/system_info/system_info_locale.h
@@ -22,7 +22,7 @@ class SysInfoLocale {
  public:
   explicit SysInfoLocale(ContextAPI* api);
   ~SysInfoLocale();
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   void StartListening();
   void StopListening();
 

--- a/system_info/system_info_locale_desktop.cc
+++ b/system_info/system_info_locale_desktop.cc
@@ -34,7 +34,7 @@ void SysInfoLocale::StopListening() {
     g_source_remove(timeout_cb_id_);
 }
 
-void SysInfoLocale::Get(picojson::value& error,
+void SysInfoLocale::Get(picojson::value& error, //NOLINT
                        picojson::value& data) {
   // language
   if (!GetLanguage()) {

--- a/system_info/system_info_locale_mobile.cc
+++ b/system_info/system_info_locale_mobile.cc
@@ -61,7 +61,7 @@ void SysInfoLocale::OnCountryChanged(keynode_t* node, void* user_data) {
   free(country);
 }
 
-void SysInfoLocale::Get(picojson::value& error,
+void SysInfoLocale::Get(picojson::value& error, //NOLINT
                        picojson::value& data) {
   // language
   if (!GetLanguage()) {

--- a/system_info/system_info_network.cc
+++ b/system_info/system_info_network.cc
@@ -12,7 +12,7 @@ SysInfoNetwork::SysInfoNetwork(ContextAPI* api)
   PlatformInitialize();
 }
 
-void SysInfoNetwork::Get(picojson::value& error,
+void SysInfoNetwork::Get(picojson::value& error, //NOLINT
                          picojson::value& data) {
   if (!Update(error)) {
     if (error.get("message").to_str().empty())
@@ -58,7 +58,7 @@ SysInfoNetwork::ToNetworkTypeString(SystemInfoNetworkType type) {
   return ret;
 }
 
-void SysInfoNetwork::SetData(picojson::value& data) {
+void SysInfoNetwork::SetData(picojson::value& data) { //NOLINT
   system_info::SetPicoJsonObjectValue(data, "networkType",
       picojson::value(ToNetworkTypeString(type_)));
 }

--- a/system_info/system_info_network.h
+++ b/system_info/system_info_network.h
@@ -41,7 +41,7 @@ class SysInfoNetwork {
  public:
   explicit SysInfoNetwork(ContextAPI* api);
   ~SysInfoNetwork();
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   inline void StartListening() {
 #if defined(TIZEN_MOBILE)
     timeout_cb_id_ = g_timeout_add(system_info::default_timeout_interval,
@@ -60,8 +60,8 @@ class SysInfoNetwork {
  private:
   void PlatformInitialize();
 
-  bool Update(picojson::value& error);
-  void SetData(picojson::value& data);
+  bool Update(picojson::value& error); //NOLINT
+  void SetData(picojson::value& data); //NOLINT
   std::string ToNetworkTypeString(SystemInfoNetworkType type);
 
   ContextAPI* api_;

--- a/system_info/system_info_network_desktop.cc
+++ b/system_info/system_info_network_desktop.cc
@@ -100,7 +100,7 @@ void SysInfoNetwork::OnDevicesCreated(GObject*, GAsyncResult* res) {
   UpdateDeviceType(value);
 }
 
-bool SysInfoNetwork::Update(picojson::value& error) {
+bool SysInfoNetwork::Update(picojson::value& error) { //NOLINT
   // type_ will be updated by NM signals
   return true;
 }

--- a/system_info/system_info_network_mobile.cc
+++ b/system_info/system_info_network_mobile.cc
@@ -15,7 +15,7 @@ void SysInfoNetwork::PlatformInitialize() {
   timeout_cb_id_ = 0;
 }
 
-bool SysInfoNetwork::Update(picojson::value& error) {
+bool SysInfoNetwork::Update(picojson::value& error) { //NOLINT
   int service_type = 0;
   if (vconf_get_int(VCONFKEY_TELEPHONY_SVCTYPE, &service_type)) {
     return false;

--- a/system_info/system_info_peripheral.h
+++ b/system_info/system_info_peripheral.h
@@ -24,7 +24,7 @@ class SysInfoPeripheral {
     if (isRegister_)
       StopListening();
 }
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   void StartListening();
   void StopListening();
 
@@ -34,7 +34,7 @@ class SysInfoPeripheral {
   void SetHDMI(int hdmi);
 
   void UpdateIsVideoOutputOn();
-  void SendData(picojson::value& data);
+  void SendData(picojson::value& data); //NOLINT
 
   static void OnWFDChanged(keynode_t* node, void* user_data);
   static void OnHDMIChanged(keynode_t* node, void* user_data);

--- a/system_info/system_info_peripheral_desktop.cc
+++ b/system_info/system_info_peripheral_desktop.cc
@@ -6,7 +6,7 @@
 
 #include "system_info/system_info_utils.h"
 
-void SysInfoPeripheral::Get(picojson::value& error,
+void SysInfoPeripheral::Get(picojson::value& error, //NOLINT
                             picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Peripheral is not supported on desktop."));

--- a/system_info/system_info_peripheral_mobile.cc
+++ b/system_info/system_info_peripheral_mobile.cc
@@ -6,7 +6,7 @@
 
 #include "system_info/system_info_utils.h"
 
-void SysInfoPeripheral::Get(picojson::value& error,
+void SysInfoPeripheral::Get(picojson::value& error, //NOLINT
                             picojson::value& data) {
   if (vconf_get_int(VCONFKEY_MIRACAST_WFD_SOURCE_STATUS, &wfd_) != 0) {
     system_info::SetPicoJsonObjectValue(error, "message",
@@ -24,7 +24,7 @@ void SysInfoPeripheral::Get(picojson::value& error,
   system_info::SetPicoJsonObjectValue(error, "message", picojson::value(""));
 }
 
-void SysInfoPeripheral::SendData(picojson::value& data) {
+void SysInfoPeripheral::SendData(picojson::value& data) { //NOLINT
   is_video_output_ = (wfd_ == VCONFKEY_MIRACAST_WFD_SOURCE_ON) ||
                      (hdmi_ == VCONFKEY_SYSMAN_HDMI_CONNECTED);
   system_info::SetPicoJsonObjectValue(data, "isVideoOutputOn",

--- a/system_info/system_info_sim.h
+++ b/system_info/system_info_sim.h
@@ -25,7 +25,7 @@ class SysInfoSim {
     if (isRegister_)
       StopListening();
 }
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   void StartListening();
   void StopListening();
 

--- a/system_info/system_info_sim_desktop.cc
+++ b/system_info/system_info_sim_desktop.cc
@@ -6,7 +6,7 @@
 
 #include "system_info/system_info_utils.h"
 
-void SysInfoSim::Get(picojson::value& error,
+void SysInfoSim::Get(picojson::value& error, //NOLINT
                      picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("SIM is not supported on desktop."));

--- a/system_info/system_info_sim_mobile.cc
+++ b/system_info/system_info_sim_mobile.cc
@@ -6,7 +6,7 @@
 
 #include "system_info/system_info_utils.h"
 
-void SysInfoSim::Get(picojson::value& error,
+void SysInfoSim::Get(picojson::value& error, //NOLINT
                      picojson::value& data) {
   char* s = NULL;
 

--- a/system_info/system_info_storage.cc
+++ b/system_info/system_info_storage.cc
@@ -7,7 +7,7 @@
 #include "common/picojson.h"
 #include "system_info/system_info_utils.h"
 
-void SysInfoStorage::Get(picojson::value& error,
+void SysInfoStorage::Get(picojson::value& error, //NOLINT
                          picojson::value& data) {
   if (!Update(error)) {
     if (error.get("message").to_str().empty())

--- a/system_info/system_info_storage.h
+++ b/system_info/system_info_storage.h
@@ -20,7 +20,7 @@ class SysInfoStorage {
  public:
   explicit SysInfoStorage(ContextAPI* api);
   ~SysInfoStorage();
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   inline void StartListening() {
     // FIXME(halton): Use udev D-Bus interface to monitor.
     timeout_cb_id_ = g_timeout_add(system_info::default_timeout_interval,
@@ -33,7 +33,7 @@ class SysInfoStorage {
 }
 
  private:
-  bool Update(picojson::value& error);
+  bool Update(picojson::value& error); //NOLINT
   static gboolean OnUpdateTimeout(gpointer user_data);
 
   int timeout_cb_id_;
@@ -50,8 +50,8 @@ class SysInfoStorage {
 
   struct udev* udev_;
 #elif defined(TIZEN_MOBILE)
-  bool GetInternal(picojson::value& error, picojson::value& unit);
-  bool GetMMC(picojson::value& error, picojson::value& unit);
+  bool GetInternal(picojson::value& error, picojson::value& unit); //NOLINT
+  bool GetMMC(picojson::value& error, picojson::value& unit); //NOLINT
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoStorage);

--- a/system_info/system_info_storage_desktop.cc
+++ b/system_info/system_info_storage_desktop.cc
@@ -29,7 +29,7 @@ SysInfoStorage::~SysInfoStorage() {
     udev_unref(udev_);
 }
 
-bool SysInfoStorage::Update(picojson::value& error) {
+bool SysInfoStorage::Update(picojson::value& error) { //NOLINT
   picojson::array& units_arr = units_.get<picojson::array>();
   units_arr.clear();
 

--- a/system_info/system_info_storage_mobile.cc
+++ b/system_info/system_info_storage_mobile.cc
@@ -28,7 +28,7 @@ SysInfoStorage::~SysInfoStorage() {
       g_source_remove(timeout_cb_id_);
 }
 
-bool SysInfoStorage::Update(picojson::value& error) {
+bool SysInfoStorage::Update(picojson::value& error) { //NOLINT
   picojson::array& units_arr = units_.get<picojson::array>();
   units_arr.clear();
 
@@ -44,7 +44,7 @@ bool SysInfoStorage::Update(picojson::value& error) {
   return true;
 }
 
-bool SysInfoStorage::GetInternal(picojson::value& error,
+bool SysInfoStorage::GetInternal(picojson::value& error, //NOLINT
                                  picojson::value& unit) {
   struct statfs fs;
   if (statfs(sStorageInternalPath, &fs) < 0) {
@@ -73,7 +73,7 @@ bool SysInfoStorage::GetInternal(picojson::value& error,
   return true;
 }
 
-bool SysInfoStorage::GetMMC(picojson::value& error, picojson::value& unit) {
+bool SysInfoStorage::GetMMC(picojson::value& error, picojson::value& unit) { //NOLINT
   int sdcard_state;
   if ((vconf_get_int(VCONFKEY_SYSMAN_MMC_STATUS, &sdcard_state) != 0) ||
       (sdcard_state != VCONFKEY_SYSMAN_MMC_MOUNTED)) {

--- a/system_info/system_info_utils.cc
+++ b/system_info/system_info_utils.cc
@@ -50,7 +50,7 @@ std::string GetUdevProperty(struct udev_device* dev,
   return std::string(udev_list_entry_get_value(attr_entry));
 }
 
-void SetPicoJsonObjectValue(picojson::value& obj,
+void SetPicoJsonObjectValue(picojson::value& obj, //NOLINT
                             const char* prop,
                             const picojson::value& val) {
   picojson::object& o = obj.get<picojson::object>();

--- a/system_info/system_info_utils.h
+++ b/system_info/system_info_utils.h
@@ -20,7 +20,7 @@ int ReadOneByte(const char* path);
 char* ReadOneLine(const char* path);
 std::string GetUdevProperty(struct udev_device* dev,
                               const std::string& attr);
-void SetPicoJsonObjectValue(picojson::value& obj,
+void SetPicoJsonObjectValue(picojson::value& obj, //NOLINT
                             const char* prop,
                             const picojson::value& val);
 

--- a/system_info/system_info_wifi_network.cc
+++ b/system_info/system_info_wifi_network.cc
@@ -16,7 +16,7 @@ SysInfoWifiNetwork::SysInfoWifiNetwork(ContextAPI* api)
   PlatformInitialize();
 }
 
-void SysInfoWifiNetwork::Get(picojson::value& error,
+void SysInfoWifiNetwork::Get(picojson::value& error, //NOLINT
                              picojson::value& data) {
   if (!Update(error)) {
     if (error.get("message").to_str().empty())

--- a/system_info/system_info_wifi_network.h
+++ b/system_info/system_info_wifi_network.h
@@ -31,7 +31,7 @@ class SysInfoWifiNetwork {
  public:
   explicit SysInfoWifiNetwork(ContextAPI* api);
   ~SysInfoWifiNetwork();
-  void Get(picojson::value& error, picojson::value& data);
+  void Get(picojson::value& error, picojson::value& data); //NOLINT
   inline void StartListening() {
 #if defined(TIZEN_MOBILE)
     timeout_cb_id_ = g_timeout_add(system_info::default_timeout_interval,
@@ -50,9 +50,9 @@ class SysInfoWifiNetwork {
  private:
   void PlatformInitialize();
 
-  bool Update(picojson::value& error);
+  bool Update(picojson::value& error); //NOLINT
   void SendUpdate();
-  void SetData(picojson::value& data);
+  void SetData(picojson::value& data); //NOLINT
 
   ContextAPI* api_;
   double signal_strength_;

--- a/system_info/system_info_wifi_network_desktop.cc
+++ b/system_info/system_info_wifi_network_desktop.cc
@@ -32,7 +32,7 @@ void SysInfoWifiNetwork::PlatformInitialize() {
 SysInfoWifiNetwork::~SysInfoWifiNetwork() {
 }
 
-void SysInfoWifiNetwork::SetData(picojson::value& data) {
+void SysInfoWifiNetwork::SetData(picojson::value& data) { //NOLINT
   system_info::SetPicoJsonObjectValue(data, "status",
       picojson::value(status_));
   system_info::SetPicoJsonObjectValue(data, "ssid",
@@ -45,7 +45,7 @@ void SysInfoWifiNetwork::SetData(picojson::value& data) {
       picojson::value(signal_strength_));
 }
 
-bool SysInfoWifiNetwork::Update(picojson::value& error) {
+bool SysInfoWifiNetwork::Update(picojson::value& error) { //NOLINT
   // The type_ will be updated by NM signals.
   return true;
 }

--- a/system_info/system_info_wifi_network_mobile.cc
+++ b/system_info/system_info_wifi_network_mobile.cc
@@ -20,7 +20,7 @@ void SysInfoWifiNetwork::PlatformInitialize() {
   timeout_cb_id_ = 0;
 }
 
-bool SysInfoWifiNetwork::Update(picojson::value& error) {
+bool SysInfoWifiNetwork::Update(picojson::value& error) { //NOLINT
   connection_h connect = NULL;
   if (connection_create(&connect) != CONNECTION_ERROR_NONE) {
     if (error.get("message").to_str().empty())
@@ -101,7 +101,7 @@ bool SysInfoWifiNetwork::Update(picojson::value& error) {
   return true;
 }
 
-void SysInfoWifiNetwork::SetData(picojson::value& data) {
+void SysInfoWifiNetwork::SetData(picojson::value& data) { //NOLINT
   system_info::SetPicoJsonObjectValue(data, "status",
       picojson::value(status_));
   system_info::SetPicoJsonObjectValue(data, "ssid",


### PR DESCRIPTION
The patch makes Trybot's coding style checking ignore the const reference warning in SystemInfo API.
