### PR TITLE
Allow run tools/check-coding-style from any place

### DIFF
--- a/tools/check-coding-style
+++ b/tools/check-coding-style
@@ -8,6 +8,11 @@ if [ ! `which cpplint.py` ]; then
    exit 1
 fi
 
+# Store current dir and change to repository root dir.
+OLD_PWD=$PWD
+SELF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SELF_DIR/..
+
 # FIXME(cmarcelo): the exception 'runtime/references' is for system_info/, we
 # need to verify whether is really necessary or should be fixed.
 FILTERS="-readability/streams,-runtime/references"
@@ -24,3 +29,8 @@ cpplint.py --filter="$FILTERS" $(find \
                                ! -path './bluetooth/*' \
                                ! -path './download/*' \
                                \( -name '*.h' -o -name '*.cc' \) )
+
+# Return to previous dir and return the code returned by cpplint.py
+RET_VAL=$?
+cd $OLD_PWD
+exit $RET_VAL


### PR DESCRIPTION
Currently `tools/check-coding-style` need run under root of t-e-c, this change is to improve it can be run from any place. It is needed by trybot.
