### PR TITLE
[SystemInfo] Fixed SIM callback error and type mismatch error

### DIFF
--- a/system_info/system_info_sim.h
+++ b/system_info/system_info_sim.h
@@ -6,7 +6,10 @@
 #define SYSTEM_INFO_SYSTEM_INFO_SIM_H_
 
 #if defined(TIZEN_MOBILE)
+#include <errno.h>
 #include <sim.h>
+#include <stdlib.h>
+#include <stdio.h>
 #endif
 #include <string>
 
@@ -44,26 +47,47 @@ class SysInfoSim {
   };
 
 #if defined(TIZEN_MOBILE)
+  typedef int (*SIMGetterFunction1)(char** out);
+  typedef int (*SIMGetterFunction2)(char** out1, char** out2);
+
   static void OnSimStateChanged(sim_state_e state, void *user_data);
 #endif
 
  private:
   explicit SysInfoSim()
-      : state_(SYSTEM_INFO_SIM_UNKNOWN) {
+      : state_(SYSTEM_INFO_SIM_UNKNOWN),
+        operatorName_(""),
+        msisdn_(""),
+        iccid_(""),
+        mcc_(0),
+        mnc_(0),
+        msin_(""),
+        spn_("") {
     pthread_mutex_init(&events_list_mutex_, NULL);
   }
 
 #if defined(TIZEN_MOBILE)
+  bool QuerySIMStatus();
+  bool QuerySIM(SIMGetterFunction1 getter,
+                std::string& member,
+                const std::string& default_value = "N/A");
+  bool QuerySIM(SIMGetterFunction2 getter,
+                std::string& member,
+                const std::string& default_value = "N/A");
+  bool QuerySIM(SIMGetterFunction1 getter,
+                unsigned int& member,
+                const unsigned int& default_value = 0);
+  void SetJsonValues(picojson::value& data);
   std::string ToSimStateString(SystemInfoSimState state);
-  SystemInfoSimState Get_systeminfo_sim_state(sim_state_e state);
+  SystemInfoSimState GetSystemInfoSIMState(sim_state_e state);
 #endif
 
   SystemInfoSimState state_;
   std::string operatorName_;
   std::string msisdn_;
   std::string iccid_;
-  std::string mcc_;
-  std::string mnc_;
+  unsigned int mcc_;
+  unsigned int mnc_;
   std::string msin_;
   std::string spn_;
   pthread_mutex_t events_list_mutex_;


### PR DESCRIPTION
The old design principle was if sim_get_*\* API's return value didn't equal SIM_ERROR_NONE, 
we return an error callback. However, if the SIM status is not READY, other attributes won't be 
gotten (sim_get_*\* won't return SIM_ERROR_NONE). So, here, we add sim_get_*\* API return 
value's checking. If the return value equals SIM_ERROR_NOT_AVAILABLE, we reset the according
 attribute's value to empty and return true.
