### PR TITLE
bluetooth: Add a simple workaround for setPowered()

### DIFF
--- a/bluetooth/bluetooth_api.js
+++ b/bluetooth/bluetooth_api.js
@@ -353,6 +353,15 @@ BluetoothAdapter.prototype.setName = function(name, successCallback, errorCallba
 };
 
 BluetoothAdapter.prototype.setPowered = function(state, successCallback, errorCallback) {
+  // FIXME: Until there is a proper solution for the problem that the adapter disappears
+  // from the USB bus when it is powered down, we can only work around this issue, this
+  // is the simplest one.
+  if (state && defaultAdapter.powered
+      && successCallback && typeof successCallback === 'function') {
+    successCallback();
+    return;
+  }
+
   throw new tizen.WebAPIException(tizen.WebAPIException.NOT_SUPPORTED_ERR);
 };
 


### PR DESCRIPTION
When the adapter is already powered we may just call the callback.

This is just a temporary solution until there is a proper solution for
the problem of the adapter exiting the USB bus, when it is powered down.
