### PR TITLE
[Bluetooth] Fixes dealing with sync replies and the instance destruction

### DIFF
--- a/bluetooth/bluetooth_context.cc
+++ b/bluetooth/bluetooth_context.cc
@@ -87,14 +87,16 @@ void BluetoothContext::HandleDiscoverDevices(const picojson::value& msg) {
   discover_callback_id_ = msg.get("reply_id").to_str();
   if (adapter_proxy_)
     g_dbus_proxy_call(adapter_proxy_, "StartDiscovery", NULL,
-        G_DBUS_CALL_FLAGS_NONE, 20000, NULL, OnDiscoveryStartedThunk, this);
+                      G_DBUS_CALL_FLAGS_NONE, 20000, NULL, OnDiscoveryStartedThunk,
+                      CancellableWrap(all_pending_, this));
 }
 
 void BluetoothContext::HandleStopDiscovery(const picojson::value& msg) {
   stop_discovery_callback_id_ = msg.get("reply_id").to_str();
   if (adapter_proxy_)
     g_dbus_proxy_call(adapter_proxy_, "StopDiscovery", NULL,
-        G_DBUS_CALL_FLAGS_NONE, 20000, NULL, OnDiscoveryStoppedThunk, this);
+                      G_DBUS_CALL_FLAGS_NONE, 20000, NULL, OnDiscoveryStoppedThunk,
+                      CancellableWrap(all_pending_, this));
 }
 
 void BluetoothContext::OnDiscoveryStarted(GObject*, GAsyncResult* res) {


### PR DESCRIPTION
Now that we are able to send replies to sync messages outside the context of the SyncMessage handler, we may handle the getDefaultAdapter() call properly.

This series also includes a fix for dealing with the case that the instance is destroyed and there's a pending D-Bus message.
