### PR TITLE
[SystemInfo] Use singleton model to support multi frames

### DIFF
--- a/system_info/system_info_battery.h
+++ b/system_info/system_info_battery.h
@@ -20,19 +20,25 @@
 
 class SysInfoBattery {
  public:
-  explicit SysInfoBattery(ContextAPI* api);
+  static SysInfoBattery& GetSysInfoBattery() {
+    static SysInfoBattery instance;
+    return instance;
+  }
+
   ~SysInfoBattery();
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening();
-  void StopListening();
+  void StartListening(ContextAPI* api);
+  void StopListening(ContextAPI* api);
 
  private:
+  explicit SysInfoBattery();
   bool Update(picojson::value& error);
   void SetData(picojson::value& data);
 
 #if defined(GENERIC_DESKTOP)
   static gboolean OnUpdateTimeout(gpointer user_data);
 
+  udev* udev_;
   int timeout_cb_id_;
 #elif defined(TIZEN_MOBILE)
   void UpdateLevel(double level);
@@ -40,13 +46,11 @@ class SysInfoBattery {
   static void OnLevelChanged(keynode_t* node, void* user_data);
   static void OnIsChargingChanged(keynode_t* node, void* user_data);
 
-  bool is_registered_;
 #endif
 
-  ContextAPI* api_;
-  struct udev* udev_;
   double level_;
   bool charging_;
+  pthread_mutex_t events_list_mutex_;
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoBattery);
 };

--- a/system_info/system_info_build_mobile.cc
+++ b/system_info/system_info_build_mobile.cc
@@ -10,17 +10,6 @@
 #endif
 
 #include "common/picojson.h"
-#include "system_info/system_info_utils.h"
-
-SysInfoBuild::SysInfoBuild(ContextAPI* api)
-    : timeout_cb_id_(0) {
-  api_ = api;
-}
-
-SysInfoBuild::~SysInfoBuild() {
-    if (timeout_cb_id_ > 0)
-      g_source_remove(timeout_cb_id_);
-}
 
 void SysInfoBuild::Get(picojson::value& error,
                        picojson::value& data) {
@@ -123,7 +112,12 @@ gboolean SysInfoBuild::OnUpdateTimeout(gpointer user_data) {
     system_info::SetPicoJsonObjectValue(output, "data", data);
 
     std::string result = output.serialize();
-    instance->api_->PostMessage(result.c_str());
+    const char* result_as_cstr = result.c_str();
+    AutoLock lock(&(instance->events_list_mutex_));
+    for (SystemInfoEventsList::iterator it = build_events_.begin();
+         it != build_events_.end(); it++) {
+      (*it)->PostMessage(result_as_cstr);
+    }
   }
 
   return TRUE;

--- a/system_info/system_info_cellular_network_desktop.cc
+++ b/system_info/system_info_cellular_network_desktop.cc
@@ -4,13 +4,11 @@
 
 #include "system_info/system_info_cellular_network.h"
 
-#include "system_info/system_info_utils.h"
-
 void SysInfoCellularNetwork::Get(picojson::value& error,
                                  picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Cellular Network is not supported on desktop."));
 }
 
-void SysInfoCellularNetwork::StartListening() { }
-void SysInfoCellularNetwork::StopListening() { }
+void SysInfoCellularNetwork::StartListening(ContextAPI* api) { }
+void SysInfoCellularNetwork::StopListening(ContextAPI* api) { }

--- a/system_info/system_info_cellular_network_mobile.cc
+++ b/system_info/system_info_cellular_network_mobile.cc
@@ -7,8 +7,6 @@
 #include <net_connection.h>
 #include <system_info.h>
 
-#include "system_info/system_info_utils.h"
-
 void SysInfoCellularNetwork::SetCellStatus() {
   int cell_status = 0;
 
@@ -178,7 +176,12 @@ void SysInfoCellularNetwork::SendUpdate() {
   system_info::SetPicoJsonObjectValue(output, "data", data);
 
   std::string result = output.serialize();
-  api_->PostMessage(result.c_str());
+  const char* result_as_cstr = result.c_str();
+  AutoLock lock(&events_list_mutex_);
+  for (SystemInfoEventsList::iterator it = cellular_events_.begin();
+       it != cellular_events_.end(); it++) {
+    (*it)->PostMessage(result_as_cstr);
+  }
 }
 
 void SysInfoCellularNetwork::UpdateCellStatus(int status) {
@@ -308,43 +311,44 @@ void SysInfoCellularNetwork::OnFlightModeChanged(keynode_t* node,
   cellular->UpdateFlightMode(flight_mode);
 }
 
-void SysInfoCellularNetwork::StartListening() {
+void SysInfoCellularNetwork::StartListening(ContextAPI* api) {
+  AutoLock lock(&events_list_mutex_);
+  cellular_events_.push_back(api);
+
+  if (cellular_events_.size() > 1)
+    return;
+
   vconf_notify_key_changed(VCONFKEY_3G_ENABLE,
       (vconf_callback_fn)OnCellStatusChanged, this);
-
   vconf_notify_key_changed(VCONFKEY_NETWORK_IP,
       (vconf_callback_fn)OnIpChanged, this);
-
   vconf_notify_key_changed(VCONFKEY_TELEPHONY_CELLID,
       (vconf_callback_fn)OnCellIdChanged, this);
-
   vconf_notify_key_changed(VCONFKEY_TELEPHONY_LAC,
       (vconf_callback_fn)OnLocationAreaCodeChanged, this);
-
   vconf_notify_key_changed(VCONFKEY_TELEPHONY_SVC_ROAM,
       (vconf_callback_fn)OnRoamingStateChanged, this);
-
   vconf_notify_key_changed(VCONFKEY_TELEPHONY_FLIGHT_MODE,
       (vconf_callback_fn)OnFlightModeChanged, this);
-  isRegister_ = true;
 }
 
-void SysInfoCellularNetwork::StopListening() {
+void SysInfoCellularNetwork::StopListening(ContextAPI* api) {
+  AutoLock lock(&events_list_mutex_);
+  cellular_events_.remove(api);
+
+  if (!cellular_events_.empty())
+    return;
+
   vconf_ignore_key_changed(VCONFKEY_3G_ENABLE,
       (vconf_callback_fn)OnCellStatusChanged);
-
-  vconf_ignore_key_changed(VCONFKEY_NETWORK_IP, (vconf_callback_fn)OnIpChanged);
-
+  vconf_ignore_key_changed(VCONFKEY_NETWORK_IP,
+      (vconf_callback_fn)OnIpChanged);
   vconf_ignore_key_changed(VCONFKEY_TELEPHONY_CELLID,
       (vconf_callback_fn)OnCellIdChanged);
-
   vconf_ignore_key_changed(VCONFKEY_TELEPHONY_LAC,
       (vconf_callback_fn)OnLocationAreaCodeChanged);
-
   vconf_ignore_key_changed(VCONFKEY_TELEPHONY_SVC_ROAM,
       (vconf_callback_fn)OnRoamingStateChanged);
-
   vconf_ignore_key_changed(VCONFKEY_TELEPHONY_FLIGHT_MODE,
       (vconf_callback_fn)OnFlightModeChanged);
-  isRegister_ = false;
 }

--- a/system_info/system_info_context.cc
+++ b/system_info/system_info_context.cc
@@ -18,33 +18,35 @@ DEFINE_XWALK_EXTENSION(SystemInfoContext);
 
 SystemInfoContext::SystemInfoContext(ContextAPI* api)
     : api_(api),
-      battery_(new SysInfoBattery(api)),
-      build_(new SysInfoBuild(api)),
-      cellular_network_(new SysInfoCellularNetwork(api)),
-      cpu_(new SysInfoCpu(api)),
-      device_orientation_(new SysInfoDeviceOrientation(api)),
-      display_(new SysInfoDisplay(api)),
-      locale_(new SysInfoLocale(api)),
-      sim_(new SysInfoSim(api)),
-      storage_(new SysInfoStorage(api)),
-      network_(new SysInfoNetwork(api)),
-      peripheral_(new SysInfoPeripheral(api)),
-      wifi_network_(new SysInfoWifiNetwork(api)) {
+      battery_(SysInfoBattery::GetSysInfoBattery()),
+      build_(SysInfoBuild::GetSysInfoBuild()),
+      cellular_network_(
+          SysInfoCellularNetwork::GetSysInfoCellularNetwork()),
+      cpu_(SysInfoCpu::GetSysInfoCpu()),
+      device_orientation_(
+          SysInfoDeviceOrientation::GetSysInfoDeviceOrientation()),
+      display_(SysInfoDisplay::GetSysInfoDisplay()),
+      locale_(SysInfoLocale::GetSysInfoLocale()),
+      sim_(SysInfoSim::GetSysInfoSim()),
+      storage_(SysInfoStorage::GetSysInfoStorage()),
+      network_(SysInfoNetwork::GetSysInfoNetwork()),
+      peripheral_(SysInfoPeripheral::GetSysInfoPeripheral()),
+      wifi_network_(SysInfoWifiNetwork::GetSysInfoWifiNetwork()) {
 }
 
 SystemInfoContext::~SystemInfoContext() {
-  delete wifi_network_;
-  delete peripheral_;
-  delete network_;
-  delete storage_;
-  delete sim_;
-  delete locale_;
-  delete display_;
-  delete device_orientation_;
-  delete cpu_;
-  delete cellular_network_;
-  delete build_;
-  delete battery_;
+  cpu_.StopListening(api_);
+  wifi_network_.StopListening(api_);
+  peripheral_.StopListening(api_);
+  network_.StopListening(api_);
+  storage_.StopListening(api_);
+  sim_.StopListening(api_);
+  locale_.StopListening(api_);
+  display_.StopListening(api_);
+  device_orientation_.StopListening(api_);
+  cellular_network_.StopListening(api_);
+  build_.StopListening(api_);
+  battery_.StopListening(api_);
   delete api_;
 }
 
@@ -70,29 +72,29 @@ void SystemInfoContext::HandleGetPropertyValue(const picojson::value& input,
   std::string prop = input.get("prop").to_str();
 
   if (prop == "BATTERY") {
-    battery_->Get(error, data);
+    battery_.Get(error, data);
   } else if (prop == "CPU") {
-    cpu_->Get(error, data);
+    cpu_.Get(error, data);
   } else if (prop == "STORAGE") {
-    storage_->Get(error, data);
+    storage_.Get(error, data);
   } else if (prop == "DISPLAY") {
-    display_->Get(error, data);
+    display_.Get(error, data);
   } else if (prop == "DEVICE_ORIENTATION") {
-    device_orientation_->Get(error, data);
+    device_orientation_.Get(error, data);
   } else if (prop == "BUILD") {
-    build_->Get(error, data);
+    build_.Get(error, data);
   } else if (prop == "LOCALE") {
-    locale_->Get(error, data);
+    locale_.Get(error, data);
   } else if (prop == "NETWORK") {
-    network_->Get(error, data);
+    network_.Get(error, data);
   } else if (prop == "WIFI_NETWORK") {
-    wifi_network_->Get(error, data);
+    wifi_network_.Get(error, data);
   } else if (prop == "CELLULAR_NETWORK") {
-    cellular_network_->Get(error, data);
+    cellular_network_.Get(error, data);
   } else if (prop == "SIM") {
-    sim_->Get(error, data);
+    sim_.Get(error, data);
   } else if (prop == "PERIPHERAL") {
-    peripheral_->Get(error, data);
+    peripheral_.Get(error, data);
   } else {
     system_info::SetPicoJsonObjectValue(error, "message",
         picojson::value("Not supported property " + prop));
@@ -112,29 +114,29 @@ void SystemInfoContext::HandleStartListening(const picojson::value& input) {
   std::string prop = input.get("prop").to_str();
 
   if (prop == "BATTERY") {
-    battery_->StartListening();
+    battery_.StartListening(api_);
   } else if (prop == "CPU") {
-    cpu_->StartListening();
+    cpu_.StartListening(api_);
   } else if (prop == "STORAGE") {
-    storage_->StartListening();
+    storage_.StartListening(api_);
   } else if (prop == "DISPLAY") {
-    display_->StartListening();
+    display_.StartListening(api_);
   } else if (prop == "DEVICE_ORIENTATION") {
-    device_orientation_->StartListening();
+    device_orientation_.StartListening(api_);
   } else if (prop == "BUILD") {
-    build_->StartListening();
+    build_.StartListening(api_);
   } else if (prop == "LOCALE") {
-    locale_->StartListening();
+    locale_.StartListening(api_);
   } else if (prop == "NETWORK") {
-    network_->StartListening();
+    network_.StartListening(api_);
   } else if (prop == "WIFI_NETWORK") {
-    wifi_network_->StartListening();
+    wifi_network_.StartListening(api_);
   } else if (prop == "CELLULAR_NETWORK") {
-    cellular_network_->StartListening();
+    cellular_network_.StartListening(api_);
   } else if (prop == "SIM") {
-    sim_->StartListening();
+    sim_.StartListening(api_);
   } else if (prop == "PERIPHERAL") {
-    peripheral_->StartListening();
+    peripheral_.StartListening(api_);
   }
 }
 
@@ -142,29 +144,29 @@ void SystemInfoContext::HandleStopListening(const picojson::value& input) {
   std::string prop = input.get("prop").to_str();
 
   if (prop == "BATTERY") {
-    battery_->StopListening();
+    battery_.StopListening(api_);
   } else if (prop == "CPU") {
-    cpu_->StopListening();
+    cpu_.StopListening(api_);
   } else if (prop == "STORAGE") {
-    storage_->StopListening();
+    storage_.StopListening(api_);
   } else if (prop == "DISPLAY") {
-    display_->StopListening();
+    display_.StopListening(api_);
   } else if (prop == "DEVICE_ORIENTATION") {
-    device_orientation_->StopListening();
+    device_orientation_.StopListening(api_);
   } else if (prop == "BUILD") {
-    build_->StopListening();
+    build_.StopListening(api_);
   } else if (prop == "LOCALE") {
-    locale_->StopListening();
+    locale_.StopListening(api_);
   } else if (prop == "NETWORK") {
-    network_->StopListening();
+    network_.StopListening(api_);
   } else if (prop == "WIFI_NETWORK") {
-    wifi_network_->StopListening();
+    wifi_network_.StopListening(api_);
   } else if (prop == "CELLULAR_NETWORK") {
-    cellular_network_->StopListening();
+    cellular_network_.StopListening(api_);
   } else if (prop == "SIM") {
-    sim_->StopListening();
+    sim_.StopListening(api_);
   } else if (prop == "PERIPHERAL") {
-    peripheral_->StopListening();
+    peripheral_.StopListening(api_);
   }
 }
 

--- a/system_info/system_info_context.h
+++ b/system_info/system_info_context.h
@@ -49,18 +49,18 @@ class SystemInfoContext {
   }
 
   ContextAPI* api_;
-  SysInfoBattery* battery_;
-  SysInfoBuild* build_;
-  SysInfoCellularNetwork* cellular_network_;
-  SysInfoCpu* cpu_;
-  SysInfoDeviceOrientation* device_orientation_;
-  SysInfoDisplay* display_;
-  SysInfoLocale* locale_;
-  SysInfoNetwork* network_;
-  SysInfoPeripheral* peripheral_;
-  SysInfoSim* sim_;
-  SysInfoStorage* storage_;
-  SysInfoWifiNetwork* wifi_network_;
+  SysInfoBattery& battery_;
+  SysInfoBuild& build_;
+  SysInfoCellularNetwork& cellular_network_;
+  SysInfoCpu& cpu_;
+  SysInfoDeviceOrientation& device_orientation_;
+  SysInfoDisplay& display_;
+  SysInfoLocale& locale_;
+  SysInfoNetwork& network_;
+  SysInfoPeripheral& peripheral_;
+  SysInfoSim& sim_;
+  SysInfoStorage& storage_;
+  SysInfoWifiNetwork& wifi_network_;
 };
 
 #endif  // SYSTEM_INFO_SYSTEM_INFO_CONTEXT_H_

--- a/system_info/system_info_device_orientation_desktop.cc
+++ b/system_info/system_info_device_orientation_desktop.cc
@@ -4,13 +4,11 @@
 
 #include "system_info/system_info_device_orientation.h"
 
-#include "system_info/system_info_utils.h"
-
 void SysInfoDeviceOrientation::Get(picojson::value& error,
                                    picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Device Orientation is not supported on desktop."));
 }
 
-void SysInfoDeviceOrientation::StartListening() { }
-void SysInfoDeviceOrientation::StopListening() { }
+void SysInfoDeviceOrientation::StartListening(ContextAPI* api) { }
+void SysInfoDeviceOrientation::StopListening(ContextAPI* api) { }

--- a/system_info/system_info_network.cc
+++ b/system_info/system_info_network.cc
@@ -4,8 +4,6 @@
 
 #include "system_info/system_info_network.h"
 
-#include "system_info/system_info_utils.h"
-
 void SysInfoNetwork::Get(picojson::value& error,
                          picojson::value& data) {
   if (!Update(error)) {

--- a/system_info/system_info_network.h
+++ b/system_info/system_info_network.h
@@ -39,21 +39,25 @@ enum SystemInfoNetworkType {
 
 class SysInfoNetwork {
  public:
-  explicit SysInfoNetwork(ContextAPI* api);
+  static SysInfoNetwork& GetSysInfoNetwork() {
+    static SysInfoNetwork instance;
+    return instance;
+  }
   ~SysInfoNetwork();
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening();
-  void StopListening();
+  void StartListening(ContextAPI* api);
+  void StopListening(ContextAPI* api);
 
  private:
+  explicit SysInfoNetwork();
   void PlatformInitialize();
 
   bool Update(picojson::value& error);
   void SetData(picojson::value& data);
   std::string ToNetworkTypeString(SystemInfoNetworkType type);
 
-  ContextAPI* api_;
   SystemInfoNetworkType type_;
+  pthread_mutex_t events_list_mutex_;
 
 #if defined(GENERIC_DESKTOP)
   G_CALLBACK_1(OnNetworkManagerCreated, GObject*, GAsyncResult*);
@@ -79,7 +83,6 @@ class SysInfoNetwork {
   bool GetNetworkType();
   static void OnTypeChanged(connection_type_e type, void* user_data);
 
-  bool is_registered_;
   connection_h connection_handle_;
 #endif
 

--- a/system_info/system_info_peripheral_desktop.cc
+++ b/system_info/system_info_peripheral_desktop.cc
@@ -4,13 +4,11 @@
 
 #include "system_info/system_info_peripheral.h"
 
-#include "system_info/system_info_utils.h"
-
 void SysInfoPeripheral::Get(picojson::value& error,
                             picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Peripheral is not supported on desktop."));
 }
 
-void SysInfoPeripheral::StartListening() { }
-void SysInfoPeripheral::StopListening() { }
+void SysInfoPeripheral::StartListening(ContextAPI* api) { }
+void SysInfoPeripheral::StopListening(ContextAPI* api) { }

--- a/system_info/system_info_sim.h
+++ b/system_info/system_info_sim.h
@@ -13,21 +13,23 @@
 #include "common/extension_adapter.h"
 #include "common/picojson.h"
 #include "common/utils.h"
+#include "system_info/system_info_utils.h"
 
 class SysInfoSim {
  public:
-  explicit SysInfoSim(ContextAPI* api)
-    : state_(SYSTEM_INFO_SIM_UNKNOWN),
-      isRegister_(false) {
-    api_ = api;
+  static SysInfoSim& GetSysInfoSim() {
+    static SysInfoSim instance;
+    return instance;
   }
   ~SysInfoSim() {
-    if (isRegister_)
-      StopListening();
-}
+    for (SystemInfoEventsList::iterator it = sim_events_.begin();
+         it != sim_events_.end(); it++)
+      StopListening(*it);
+    pthread_mutex_destroy(&events_list_mutex_);
+  }
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening();
-  void StopListening();
+  void StartListening(ContextAPI* api);
+  void StopListening(ContextAPI* api);
 
   enum SystemInfoSimState {
     SYSTEM_INFO_SIM_ABSENT = 0,
@@ -46,12 +48,16 @@ class SysInfoSim {
 #endif
 
  private:
+  explicit SysInfoSim()
+      : state_(SYSTEM_INFO_SIM_UNKNOWN) {
+    pthread_mutex_init(&events_list_mutex_, NULL);
+  }
+
 #if defined(TIZEN_MOBILE)
   std::string ToSimStateString(SystemInfoSimState state);
   SystemInfoSimState Get_systeminfo_sim_state(sim_state_e state);
 #endif
 
-  ContextAPI* api_;
   SystemInfoSimState state_;
   std::string operatorName_;
   std::string msisdn_;
@@ -60,7 +66,7 @@ class SysInfoSim {
   std::string mnc_;
   std::string msin_;
   std::string spn_;
-  bool isRegister_;
+  pthread_mutex_t events_list_mutex_;
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoSim);
 };

--- a/system_info/system_info_sim_desktop.cc
+++ b/system_info/system_info_sim_desktop.cc
@@ -4,13 +4,11 @@
 
 #include "system_info/system_info_sim.h"
 
-#include "system_info/system_info_utils.h"
-
 void SysInfoSim::Get(picojson::value& error,
                      picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("SIM is not supported on desktop."));
 }
 
-void SysInfoSim::StartListening() { }
-void SysInfoSim::StopListening() { }
+void SysInfoSim::StartListening(ContextAPI* api) { }
+void SysInfoSim::StopListening(ContextAPI* api) { }

--- a/system_info/system_info_storage_desktop.cc
+++ b/system_info/system_info_storage_desktop.cc
@@ -9,7 +9,6 @@
 #include <sys/statvfs.h>
 
 #include "common/picojson.h"
-#include "system_info/system_info_utils.h"
 
 namespace {
 
@@ -17,16 +16,17 @@ const char* sMountTable = "/proc/mounts";
 
 }  // namespace
 
-SysInfoStorage::SysInfoStorage(ContextAPI* api)
-    : stopping_(false) {
-  api_ = api;
+SysInfoStorage::SysInfoStorage()
+    : timeout_cb_id_(0) {
   udev_ = udev_new();
   units_ = picojson::value(picojson::array(0));
+  pthread_mutex_init(&events_list_mutex_, NULL);
 }
 
 SysInfoStorage::~SysInfoStorage() {
   if (udev_)
     udev_unref(udev_);
+  pthread_mutex_destroy(&events_list_mutex_);
 }
 
 bool SysInfoStorage::Update(picojson::value& error) {

--- a/system_info/system_info_storage_mobile.cc
+++ b/system_info/system_info_storage_mobile.cc
@@ -8,7 +8,6 @@
 #include <vconf.h>
 
 #include "common/picojson.h"
-#include "system_info/system_info_utils.h"
 
 namespace {
 
@@ -17,15 +16,16 @@ const char* sStorageSDCardPath = "/opt/storage/sdcard";
 
 }  // namespace
 
-SysInfoStorage::SysInfoStorage(ContextAPI* api)
+SysInfoStorage::SysInfoStorage()
     : timeout_cb_id_(0) {
-  api_ = api;
   units_ = picojson::value(picojson::array(0));
+  pthread_mutex_init(&events_list_mutex_, NULL);
 }
 
 SysInfoStorage::~SysInfoStorage() {
-    if (timeout_cb_id_ > 0)
-      g_source_remove(timeout_cb_id_);
+  if (timeout_cb_id_ > 0)
+    g_source_remove(timeout_cb_id_);
+  pthread_mutex_destroy(&events_list_mutex_);
 }
 
 bool SysInfoStorage::Update(picojson::value& error) {

--- a/system_info/system_info_utils.h
+++ b/system_info/system_info_utils.h
@@ -6,9 +6,35 @@
 #define SYSTEM_INFO_SYSTEM_INFO_UTILS_H_
 
 #include <libudev.h>
+#include <pthread.h>
+
+#include <list>
 #include <string>
 
+#include "common/extension_adapter.h"
 #include "common/picojson.h"
+
+typedef std::list<ContextAPI*> SystemInfoEventsList;
+
+static SystemInfoEventsList battery_events_;
+static SystemInfoEventsList build_events_;
+static SystemInfoEventsList cellular_events_;
+static SystemInfoEventsList cpu_events_;
+static SystemInfoEventsList device_orientation_events_;
+static SystemInfoEventsList display_events_;
+static SystemInfoEventsList local_events_;
+static SystemInfoEventsList network_events_;
+static SystemInfoEventsList peripheral_events_;
+static SystemInfoEventsList sim_events_;
+static SystemInfoEventsList storage_events_;
+static SystemInfoEventsList wifi_network_events_;
+
+struct AutoLock {
+  explicit AutoLock(pthread_mutex_t* m) : m_(m) { pthread_mutex_lock(m_); }
+  ~AutoLock() { pthread_mutex_unlock(m_); }
+ private:
+  pthread_mutex_t* m_;
+};
 
 namespace system_info {
 

--- a/system_info/system_info_wifi_network.cc
+++ b/system_info/system_info_wifi_network.cc
@@ -4,8 +4,6 @@
 
 #include "system_info/system_info_wifi_network.h"
 
-#include "system_info/system_info_utils.h"
-
 void SysInfoWifiNetwork::Get(picojson::value& error,
                              picojson::value& data) {
   if (!Update(error)) {
@@ -31,5 +29,10 @@ void SysInfoWifiNetwork::SendUpdate() {
   system_info::SetPicoJsonObjectValue(output, "data", data);
 
   std::string result = output.serialize();
-  api_->PostMessage(result.c_str());
+  const char* result_as_cstr = result.c_str();
+  AutoLock lock(&events_list_mutex_);
+  for (SystemInfoEventsList::iterator it = wifi_network_events_.begin();
+    it != wifi_network_events_.end(); it++) {
+    (*it)->PostMessage(result_as_cstr);
+  }
 }

--- a/system_info/system_info_wifi_network.h
+++ b/system_info/system_info_wifi_network.h
@@ -29,25 +29,29 @@
 
 class SysInfoWifiNetwork {
  public:
-  explicit SysInfoWifiNetwork(ContextAPI* api);
+  static SysInfoWifiNetwork& GetSysInfoWifiNetwork() {
+    static SysInfoWifiNetwork instance;
+    return instance;
+  }
   ~SysInfoWifiNetwork();
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening();
-  void StopListening();
+  void StartListening(ContextAPI* api);
+  void StopListening(ContextAPI* api);
 
  private:
+  explicit SysInfoWifiNetwork();
   void PlatformInitialize();
 
   bool Update(picojson::value& error);
   void SendUpdate();
   void SetData(picojson::value& data);
 
-  ContextAPI* api_;
   double signal_strength_;
   std::string ip_address_;
   std::string ipv6_address_;
   std::string ssid_;
   std::string status_;
+  pthread_mutex_t events_list_mutex_;
 
 #if defined(GENERIC_DESKTOP)
   G_CALLBACK_WIFI(OnAccessPointCreated, GObject*, GAsyncResult*);
@@ -93,7 +97,6 @@ class SysInfoWifiNetwork {
       void* user_data);
   static void OnTypeChanged(connection_type_e type, void* user_data);
 
-  bool is_registered_;
   connection_h connection_handle_;
   connection_profile_h connection_profile_handle_;
 #endif

--- a/system_info/system_info_wifi_network_desktop.cc
+++ b/system_info/system_info_wifi_network_desktop.cc
@@ -6,8 +6,6 @@
 
 #include <NetworkManager.h>
 
-#include "system_info/system_info_utils.h"
-
 #define NM_WIRELESS              NM_DBUS_INTERFACE_DEVICE ".Wireless"
 #define NM_IP4_ADDRESS           NM_DBUS_INTERFACE_DEVICE ".Ip4Address"
 
@@ -17,14 +15,14 @@ const double kWifiSignalStrengthDivisor = 100.0;
 
 }  // namespace
 
-SysInfoWifiNetwork::SysInfoWifiNetwork(ContextAPI* api)
+SysInfoWifiNetwork::SysInfoWifiNetwork()
     : signal_strength_(0.0),
       ip_address_(""),
       ipv6_address_(""),
       ssid_(""),
       status_("OFF") {
-  api_ = api;
   PlatformInitialize();
+  pthread_mutex_init(&events_list_mutex_, NULL);
 }
 
 void SysInfoWifiNetwork::PlatformInitialize() {
@@ -46,13 +44,11 @@ void SysInfoWifiNetwork::PlatformInitialize() {
 }
 
 SysInfoWifiNetwork::~SysInfoWifiNetwork() {
+  pthread_mutex_destroy(&events_list_mutex_);
 }
 
-void SysInfoWifiNetwork::StartListening() {
-}
-
-void SysInfoWifiNetwork::StopListening() {
-}
+void SysInfoWifiNetwork::StartListening(ContextAPI* api) { }
+void SysInfoWifiNetwork::StopListening(ContextAPI* api) { }
 
 void SysInfoWifiNetwork::SetData(picojson::value& data) {
   system_info::SetPicoJsonObjectValue(data, "status",


### PR DESCRIPTION
The old design is one frame one set of listening mechanism. So when there are multi-frames, there will be multiple sets of events. However, the vconf only support to register the first one when asking twice for the same vconf_notify_key_changed with same Key and vconf_callback_fn and the others will be ignored. So, the old framework couldn't resolve the vconf issue.

The current design uses singleton event listening mechanism. Every property object (such as: cpu, local, storage ...) is singleton. Each of them will maintain an according events list. Use StartListening(Context\* api) to push back the current context to the according list. Use StopListening(Context\* api) to remove the current context from the list. When the property value changed, iterate the list to post message to all the listenng context.    
