### PR TITLE
[Power] Fix a TCT failure with isScreenOn()

### DIFF
--- a/examples/power.html
+++ b/examples/power.html
@@ -108,13 +108,8 @@ function waitForRestore() {
 function switchOffScreen() {
   // ScreenStateChangeListener will be called asynchronously, so we check it a bit later.
   tizen.power.unsetScreenStateChangeListener(ScreenStateChangeListener);
-  tizen.power.restoreScreenBrightness();
   shouldBeTrue("tizen.power.isScreenOn()");
   shouldNotThrow("tizen.power.turnScreenOff()");
-  setTimeout(waitForScreenOff, 100);
-}
-
-function waitForScreenOff() {
   shouldBeFalse("tizen.power.isScreenOn()");
   shouldNotThrow("tizen.power.turnScreenOn()");
 }

--- a/power/power_api.js
+++ b/power/power_api.js
@@ -44,13 +44,11 @@ var sendSyncMessage = function(msg) {
 };
 
 function getScreenState() {
-  if (screenState === undefined) {
     var msg = {
       'cmd': 'PowerGetScreenState'
     };
     var r = JSON.parse(sendSyncMessage(msg));
     screenState = r.state;
-  }
 }
 
 extension.setMessageListener(function(msg) {

--- a/power/power_context.h
+++ b/power/power_context.h
@@ -7,6 +7,8 @@
 
 #if defined(GENERIC_DESKTOP)
 #include <gio/gio.h>
+#else
+#include <power.h>
 #endif
 
 #include <map>
@@ -48,6 +50,9 @@ class PowerContext {
   };
 
   void OnScreenStateChanged(ResourceState state);
+#if defined(TIZEN_MOBILE)
+  void OnPlatformScreenStateChanged(power_state_e pstate);
+#endif
 
  private:
   void HandleRequest(const picojson::value& msg);
@@ -63,6 +68,9 @@ class PowerContext {
   friend void OnScreenProxyCreatedThunk(GObject* source, GAsyncResult*,
                                         gpointer);
   GDBusProxy* screen_proxy_;
+#else
+  bool pending_screen_state_change_;
+  bool pending_screen_state_reply_;
 #endif
 };
 


### PR DESCRIPTION
TCT tests are expecting turnScreenOn/Off to have a synchronous behavior
which in fact means that querying the screen state right after should
return the correct value. In fact the underlaying platform does not
necessarily switch on or off the screen right away, it may take few
ms. This patch add a synchronous behavior to isScreenOn by
making sure to return when the platform informed us about the state
change of the screen (if called previously with turnScreenOn/Off).
This is slightly better than a busy wait.
