### PR TITLE
Enable -std=c++0x

### DIFF
--- a/bluetooth/bluetooth.gyp
+++ b/bluetooth/bluetooth.gyp
@@ -16,6 +16,10 @@
       'includes': [
         '../common/pkg-config.gypi',
       ],
+      # Can't use the flag since BlueZ's bluetooth.h is not compatible with it.
+      'cflags!': [
+        '-std=c++0x',
+      ],
       'sources': [
         'bluetooth_api.js',
         'bluetooth_context.cc',

--- a/common/common.gypi
+++ b/common/common.gypi
@@ -52,6 +52,7 @@
       'utils.h',
     ],
     'cflags': [
+      '-std=c++0x',
       '-fPIC',
       '-fvisibility=hidden',
     ],


### PR DESCRIPTION
Tizen 2.x compiler is g++ 4.5.3 which already support some of the C++11
features like 'auto' and lambdas. It is fine to use those features in
the extensions.

Unfortunately there's an issue when compiling code using bluetooth.h in
C++11, so it's it disable for the tizen_bluetooth extension for now.
