### PR TITLE
[SystemInfo][DeviceOrientation] Remove 'Unknown' in status to fix TCT failure

### DIFF
--- a/system_info/system_info_device_orientation.h
+++ b/system_info/system_info_device_orientation.h
@@ -21,13 +21,12 @@ enum SystemInfoDeviceOrientationStatus {
   PORTRAIT_SECONDARY,
   LANDSCAPE_PRIMARY,
   LANDSCAPE_SECONDARY,
-  UNKNOWN
 };
 
 class SysInfoDeviceOrientation {
  public:
   explicit SysInfoDeviceOrientation(ContextAPI* api)
-    :status_(UNKNOWN),
+    :status_(PORTRAIT_PRIMARY),
      sensorHandle_(0),
      isRegister_(false) {
     api_ = api;

--- a/system_info/system_info_device_orientation_mobile.cc
+++ b/system_info/system_info_device_orientation_mobile.cc
@@ -23,7 +23,7 @@ void SysInfoDeviceOrientation::SetStatus() {
 
   int r = sf_check_rotation(&event);
   if (r < 0) {
-    status_ = UNKNOWN;
+    status_ = PORTRAIT_PRIMARY;
     return;
   }
 
@@ -78,14 +78,14 @@ std::string SysInfoDeviceOrientation::ToOrientationStatusString(
       ret = "LANDSCAPE_SECONDARY";
       break;
     default:
-      ret = "UNKNOWN";
+      ret = "PORTRAIT_PRIMARY";
   }
   return ret;
 }
 
 enum SystemInfoDeviceOrientationStatus
 SysInfoDeviceOrientation::EventToStatus(int event_data) {
-  enum SystemInfoDeviceOrientationStatus m = UNKNOWN;
+  enum SystemInfoDeviceOrientationStatus m = PORTRAIT_PRIMARY;
   switch (event_data) {
     case(ROTATION_EVENT_0):
       m = PORTRAIT_PRIMARY;
@@ -100,7 +100,7 @@ SysInfoDeviceOrientation::EventToStatus(int event_data) {
       m = LANDSCAPE_PRIMARY;
       break;
     default:
-      m = UNKNOWN;
+      m = PORTRAIT_PRIMARY;
   }
 
   return m;


### PR DESCRIPTION
In Tizen 2.1 spec, there are only 4 statuses in Device Orientation.
The former API contains an "Unknown", which make it fail in TCT test case.

The patch set the default status as "PORTRAIT_PRIMARY" instead of "Unknown".
