### PR TITLE
tools: Report JS coding style warnings in a friendlier fashion

### DIFF
--- a/tools/js_lint.sh
+++ b/tools/js_lint.sh
@@ -15,4 +15,4 @@ if [ $# -eq 0 ]; then
    exit 1
 fi
 
-gjslint --strict --nojsdoc --max_line_length 100 $1
+gjslint --strict --nojsdoc --max_line_length 100 --unix_mode $1


### PR DESCRIPTION
gjslint has a 'unix_mode' flag to enable error reporting in the
traditional Unix way ( $filename:$line ), which should play nicer
with the tools the developers already use.
