### PR TITLE
[Power] Share state changed callback between instances

### DIFF
--- a/power/mobile/power_event_source.cc
+++ b/power/mobile/power_event_source.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "power/mobile/power_event_source.h"
+
+#include <algorithm>
+#include <functional>
+
+PowerEventSource::PowerEventSource() {}
+
+PowerEventSource::~PowerEventSource() {
+  if (!listeners_.empty())
+    power_unset_changed_cb();
+}
+
+void PowerEventSource::AddListener(PowerEventListener* listener) {
+  listeners_.push_front(listener);
+  if (listeners_.size() == 1)
+    power_set_changed_cb(OnPowerChangedCallback, this);
+}
+
+void PowerEventSource::RemoveListener(PowerEventListener* listener) {
+  listeners_.remove(listener);
+  if (listeners_.empty())
+    power_unset_changed_cb();
+}
+
+// static
+void PowerEventSource::OnPowerChangedCallback(
+    power_state_e state, void* user_data) {
+  PowerEventSource* source = reinterpret_cast<PowerEventSource*>(user_data);
+  source->DispatchEvent(state);
+}
+
+void PowerEventSource::DispatchEvent(power_state_e state) {
+  auto changed_fun = std::mem_fun(&PowerEventListener::OnPowerStateChanged);
+  std::for_each(listeners_.begin(), listeners_.end(),
+                std::bind2nd(changed_fun, state));
+}

--- a/power/mobile/power_event_source.h
+++ b/power/mobile/power_event_source.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef POWER_MOBILE_POWER_EVENT_SOURCE_H_
+#define POWER_MOBILE_POWER_EVENT_SOURCE_H_
+
+#include <power.h>
+#include <list>
+
+class PowerEventListener {
+ public:
+  virtual void OnPowerStateChanged(power_state_e state) = 0;
+ protected:
+  // We don't use listener interface to destroy them, so protected and
+  // non-virtual destructor is fine.
+  ~PowerEventListener() {}
+};
+
+// Track power changed events from Tizen native library. The library supports
+// only one callback, so this class multiplexes to the different instances that
+// maybe listening for event changes.
+class PowerEventSource {
+ public:
+  PowerEventSource();
+  ~PowerEventSource();
+
+  void AddListener(PowerEventListener* listener);
+  void RemoveListener(PowerEventListener* listener);
+
+ private:
+  // Handler for callback in power.h library.
+  static void OnPowerChangedCallback(power_state_e state, void* user_data);
+
+  void DispatchEvent(power_state_e state);
+
+  std::list<PowerEventListener*> listeners_;
+};
+
+#endif  // POWER_MOBILE_POWER_EVENT_SOURCE_H_

--- a/power/power.gyp
+++ b/power/power.gyp
@@ -7,6 +7,8 @@
       'target_name': 'tizen_power',
       'type': 'loadable_module',
       'sources': [
+        'mobile/power_event_source.cc',
+        'mobile/power_event_source.h',
         'power_api.js',
         'power_extension.cc',
         'power_extension.h',

--- a/power/power_extension.cc
+++ b/power/power_extension.cc
@@ -28,7 +28,7 @@ common::Instance* PowerExtension::CreateInstance() {
 #if defined(GENERIC_DESKTOP)
   return new PowerInstanceDesktop;
 #elif defined(TIZEN_MOBILE)
-  return new PowerInstanceMobile;
+  return new PowerInstanceMobile(&power_event_source_);
 #endif
   return NULL;
 }

--- a/power/power_extension.h
+++ b/power/power_extension.h
@@ -7,6 +7,10 @@
 
 #include "common/extension.h"
 
+#if defined(TIZEN_MOBILE)
+#include "power/mobile/power_event_source.h"
+#endif
+
 class PowerExtension : public common::Extension {
  public:
   PowerExtension();
@@ -15,6 +19,10 @@ class PowerExtension : public common::Extension {
  private:
   // common::Extension implementation.
   virtual common::Instance* CreateInstance();
+
+#if defined(TIZEN_MOBILE)
+  PowerEventSource power_event_source_;
+#endif
 };
 
 #endif  // POWER_POWER_EXTENSION_H_

--- a/power/power_instance_mobile.h
+++ b/power/power_instance_mobile.h
@@ -8,20 +8,24 @@
 #include <power.h>
 #include "common/extension.h"
 #include "power/power_types.h"
+#include "power/mobile/power_event_source.h"
 
 namespace picojson {
 class value;
 }
 
 class PowerInstanceMobile
-    : public common::Instance {
+    : public common::Instance, public PowerEventListener {
  public:
-  PowerInstanceMobile();
+  explicit PowerInstanceMobile(PowerEventSource* event_source);
+  ~PowerInstanceMobile();
 
   void OnScreenStateChanged(ResourceState state);
-  void OnPlatformScreenStateChanged(power_state_e pstate);
 
  private:
+  // PowerEventListener implementation.
+  void OnPowerStateChanged(power_state_e state);
+
   // common::Instance implementation.
   virtual void HandleMessage(const char* msg);
   virtual void HandleSyncMessage(const char* msg);
@@ -34,6 +38,7 @@ class PowerInstanceMobile
 
   bool pending_screen_state_change_;
   bool pending_screen_state_reply_;
+  PowerEventSource* event_source_;
 };
 
 #endif  // POWER_POWER_INSTANCE_MOBILE_H_


### PR DESCRIPTION
The power.h library in Tizen only allows one callback for tracking state
changes, so we make this tracking for the extension, since we can have
multiple instances. Instances now add (and remove) themselves to
PowerEventSource.
