### PR TITLE
[SystemInfo][Cpu] Fixes #125 for compile warnings

### DIFF
--- a/system_info/system_info_cpu.cc
+++ b/system_info/system_info_cpu.cc
@@ -82,8 +82,11 @@ bool SysInfoCpu::UpdateLoad() {
   unsigned long long total; //NOLINT
   unsigned long long used; //NOLINT
 
-  fscanf(fp, "%*s %llu %llu %llu %llu %llu %llu %llu",
-         &user, &nice, &system, &idle, &iowait, &irq, &softirq);
+  if (fscanf(fp, "%*s %llu %llu %llu %llu %llu %llu %llu",
+             &user, &nice, &system, &idle, &iowait, &irq, &softirq) != 7) {
+      fclose(fp);
+      return false;
+  }
   fclose(fp);
 
   // The algorithm here can be found at:


### PR DESCRIPTION
Fix the problem in Issue #125.

Return false when the fscanf operation fails.
