### PR TITLE
[SystemInfo] Decouple SystemInfoContext with the multiple system info sub classes

### DIFF
--- a/system_info/system_info_battery.h
+++ b/system_info/system_info_battery.h
@@ -13,22 +13,25 @@
 #include <vconf-keys.h>
 #endif
 
+#include <string>
+
 #include "common/extension_adapter.h"
 #include "common/picojson.h"
 #include "common/utils.h"
 #include "system_info/system_info_utils.h"
 
-class SysInfoBattery {
+class SysInfoBattery : public SysInfoObject {
  public:
-  static SysInfoBattery& GetSysInfoBattery() {
+  static SysInfoObject& GetInstance() {
     static SysInfoBattery instance;
     return instance;
   }
 
-  ~SysInfoBattery();
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
+
+  static const std::string name_;
 
  private:
   explicit SysInfoBattery();
@@ -50,7 +53,6 @@ class SysInfoBattery {
 
   double level_;
   bool charging_;
-  pthread_mutex_t events_list_mutex_;
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoBattery);
 };

--- a/system_info/system_info_build_desktop.cc
+++ b/system_info/system_info_build_desktop.cc
@@ -13,6 +13,8 @@
 
 #include "common/picojson.h"
 
+const std::string SysInfoBuild::name_ = "BUILD";
+
 void SysInfoBuild::Get(picojson::value& error,
                        picojson::value& data) {
   // model and manufacturer
@@ -124,13 +126,7 @@ gboolean SysInfoBuild::OnUpdateTimeout(gpointer user_data) {
         picojson::value("BUILD"));
     system_info::SetPicoJsonObjectValue(output, "data", data);
 
-    std::string result = output.serialize();
-    const char* result_as_cstr = result.c_str();
-    AutoLock lock(&(instance->events_list_mutex_));
-    for (SystemInfoEventsList::iterator it = build_events_.begin();
-         it != build_events_.end(); it++) {
-      (*it)->PostMessage(result_as_cstr);
-    }
+    instance->PostMessageToListeners(output);;
   }
 
   return TRUE;

--- a/system_info/system_info_build_mobile.cc
+++ b/system_info/system_info_build_mobile.cc
@@ -11,6 +11,8 @@
 
 #include "common/picojson.h"
 
+const std::string SysInfoBuild::name_ = "BUILD";
+
 void SysInfoBuild::Get(picojson::value& error,
                        picojson::value& data) {
   // model and manufacturer
@@ -111,13 +113,7 @@ gboolean SysInfoBuild::OnUpdateTimeout(gpointer user_data) {
         picojson::value("BUILD"));
     system_info::SetPicoJsonObjectValue(output, "data", data);
 
-    std::string result = output.serialize();
-    const char* result_as_cstr = result.c_str();
-    AutoLock lock(&(instance->events_list_mutex_));
-    for (SystemInfoEventsList::iterator it = build_events_.begin();
-         it != build_events_.end(); it++) {
-      (*it)->PostMessage(result_as_cstr);
-    }
+    instance->PostMessageToListeners(output);;
   }
 
   return TRUE;

--- a/system_info/system_info_cellular_network.h
+++ b/system_info/system_info_cellular_network.h
@@ -17,27 +17,21 @@
 #include "common/utils.h"
 #include "system_info/system_info_utils.h"
 
-class SysInfoCellularNetwork {
+class SysInfoCellularNetwork : public SysInfoObject {
  public:
-  static SysInfoCellularNetwork& GetSysInfoCellularNetwork() {
+  static SysInfoObject& GetInstance() {
     static SysInfoCellularNetwork instance;
     return instance;
   }
-  ~SysInfoCellularNetwork() {
-    for (SystemInfoEventsList::iterator it = cellular_events_.begin();
-         it != cellular_events_.end(); it++) {
-      StopListening(*it);
-    }
-    pthread_mutex_destroy(&events_list_mutex_);
-  }
+  ~SysInfoCellularNetwork() {}
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
+
+  static const std::string name_;
 
  private:
-  explicit SysInfoCellularNetwork() {
-    pthread_mutex_init(&events_list_mutex_, NULL);
-  }
+  explicit SysInfoCellularNetwork() {}
 
 #if defined(TIZEN_MOBILE)
   void SendUpdate();
@@ -80,7 +74,6 @@ class SysInfoCellularNetwork {
   bool isRoaming_;
   bool isFlightMode_;
   std::string imei_;
-  pthread_mutex_t events_list_mutex_;
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoCellularNetwork);
 };

--- a/system_info/system_info_cellular_network_desktop.cc
+++ b/system_info/system_info_cellular_network_desktop.cc
@@ -4,11 +4,13 @@
 
 #include "system_info/system_info_cellular_network.h"
 
+const std::string SysInfoCellularNetwork::name_ = "CELLULAR_NETWORK";
+
 void SysInfoCellularNetwork::Get(picojson::value& error,
                                  picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Cellular Network is not supported on desktop."));
 }
 
-void SysInfoCellularNetwork::StartListening(ContextAPI* api) { }
-void SysInfoCellularNetwork::StopListening(ContextAPI* api) { }
+void SysInfoCellularNetwork::AddListener(ContextAPI* api) { }
+void SysInfoCellularNetwork::RemoveListener(ContextAPI* api) { }

--- a/system_info/system_info_context.h
+++ b/system_info/system_info_context.h
@@ -5,20 +5,17 @@
 #ifndef SYSTEM_INFO_SYSTEM_INFO_CONTEXT_H_
 #define SYSTEM_INFO_SYSTEM_INFO_CONTEXT_H_
 
+#include <map>
+#include <string>
+#include <utility>
+
 #include "common/extension_adapter.h"
 #include "common/picojson.h"
-#include "system_info/system_info_battery.h"
-#include "system_info/system_info_build.h"
-#include "system_info/system_info_cellular_network.h"
-#include "system_info/system_info_cpu.h"
-#include "system_info/system_info_device_orientation.h"
-#include "system_info/system_info_display.h"
-#include "system_info/system_info_locale.h"
-#include "system_info/system_info_network.h"
-#include "system_info/system_info_peripheral.h"
-#include "system_info/system_info_sim.h"
-#include "system_info/system_info_storage.h"
-#include "system_info/system_info_wifi_network.h"
+#include "system_info/system_info_utils.h"
+
+typedef std::map<std::string, SysInfoObject&> SysInfoClassMap;
+typedef SysInfoClassMap::iterator classes_iterator;
+typedef std::pair<std::string, SysInfoObject&> SysInfoClassPair;
 
 namespace picojson {
 class value;
@@ -32,8 +29,10 @@ class SystemInfoContext {
   // ExtensionAdapter implementation.
   static const char name[];
   static const char* GetJavaScript();
+  static SysInfoClassMap classes_;
   void HandleMessage(const char* message);
   void HandleSyncMessage(const char* message);
+  static void InstancesMapInitialize();
 
  private:
   void HandleGetPropertyValue(const picojson::value& input,
@@ -48,19 +47,9 @@ class SystemInfoContext {
       o[prop] = picojson::value(val);
   }
 
+  template <class T>
+  static void RegisterClass();
   ContextAPI* api_;
-  SysInfoBattery& battery_;
-  SysInfoBuild& build_;
-  SysInfoCellularNetwork& cellular_network_;
-  SysInfoCpu& cpu_;
-  SysInfoDeviceOrientation& device_orientation_;
-  SysInfoDisplay& display_;
-  SysInfoLocale& locale_;
-  SysInfoNetwork& network_;
-  SysInfoPeripheral& peripheral_;
-  SysInfoSim& sim_;
-  SysInfoStorage& storage_;
-  SysInfoWifiNetwork& wifi_network_;
 };
 
 #endif  // SYSTEM_INFO_SYSTEM_INFO_CONTEXT_H_

--- a/system_info/system_info_device_orientation.h
+++ b/system_info/system_info_device_orientation.h
@@ -24,28 +24,23 @@ enum SystemInfoDeviceOrientationStatus {
   LANDSCAPE_SECONDARY,
 };
 
-class SysInfoDeviceOrientation {
+class SysInfoDeviceOrientation : public SysInfoObject {
  public:
-  static SysInfoDeviceOrientation& GetSysInfoDeviceOrientation() {
+  static SysInfoObject& GetInstance() {
     static SysInfoDeviceOrientation instance;
     return instance;
   }
-  ~SysInfoDeviceOrientation() {
-    for (SystemInfoEventsList::iterator it = device_orientation_events_.begin();
-         it != device_orientation_events_.end(); it++)
-      StopListening(*it);
-    pthread_mutex_destroy(&events_list_mutex_);
-  }
+  ~SysInfoDeviceOrientation() {}
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
+
+  static const std::string name_;
 
  private:
   explicit SysInfoDeviceOrientation()
       : status_(PORTRAIT_PRIMARY),
-        sensorHandle_(0) {
-    pthread_mutex_init(&events_list_mutex_, NULL);
-  }
+        sensorHandle_(0) {}
 
 #if defined(TIZEN_MOBILE)
   void SetStatus();
@@ -64,7 +59,6 @@ class SysInfoDeviceOrientation {
   SystemInfoDeviceOrientationStatus status_;
   bool isAutoRotation_;
   int sensorHandle_;
-  pthread_mutex_t events_list_mutex_;
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoDeviceOrientation);
 };

--- a/system_info/system_info_device_orientation_desktop.cc
+++ b/system_info/system_info_device_orientation_desktop.cc
@@ -4,11 +4,13 @@
 
 #include "system_info/system_info_device_orientation.h"
 
+const std::string SysInfoDeviceOrientation::name_ = "DEVICE_ORIENTATION";
+
 void SysInfoDeviceOrientation::Get(picojson::value& error,
                                    picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Device Orientation is not supported on desktop."));
 }
 
-void SysInfoDeviceOrientation::StartListening(ContextAPI* api) { }
-void SysInfoDeviceOrientation::StopListening(ContextAPI* api) { }
+void SysInfoDeviceOrientation::AddListener(ContextAPI* api) { }
+void SysInfoDeviceOrientation::RemoveListener(ContextAPI* api) { }

--- a/system_info/system_info_display_x11.cc
+++ b/system_info/system_info_display_x11.cc
@@ -18,15 +18,15 @@
   #error "Unsupported platform"
 #endif
 
+const std::string SysInfoDisplay::name_ = "DISPLAY";
+
 SysInfoDisplay::SysInfoDisplay()
     : resolution_width_(0),
       resolution_height_(0),
       physical_width_(0.0),
       physical_height_(0.0),
       brightness_(0.0),
-      timeout_cb_id_(0) {
-  pthread_mutex_init(&events_list_mutex_, NULL);
-}
+      timeout_cb_id_(0) {}
 
 void SysInfoDisplay::Get(picojson::value& error,
                          picojson::value& data) {
@@ -120,13 +120,7 @@ gboolean SysInfoDisplay::OnUpdateTimeout(gpointer user_data) {
         picojson::value("DISPLAY"));
     system_info::SetPicoJsonObjectValue(output, "data", data);
 
-    std::string result = output.serialize();
-    const char* result_as_cstr = result.c_str();
-    AutoLock lock(&(instance->events_list_mutex_));
-    for (SystemInfoEventsList::iterator it = display_events_.begin();
-         it != display_events_.end(); it++) {
-      (*it)->PostMessage(result_as_cstr);
-    }
+    instance->PostMessageToListeners(output);
   }
 
   return TRUE;

--- a/system_info/system_info_locale.h
+++ b/system_info/system_info_locale.h
@@ -18,21 +18,18 @@
 #include "common/utils.h"
 #include "system_info/system_info_utils.h"
 
-class SysInfoLocale {
+class SysInfoLocale : public SysInfoObject {
  public:
-  static SysInfoLocale& GetSysInfoLocale() {
+  static SysInfoObject& GetInstance() {
     static SysInfoLocale instance;
     return instance;
   }
-  ~SysInfoLocale() {
-    for (SystemInfoEventsList::iterator it = local_events_.begin();
-         it != local_events_.end(); it++)
-      StopListening(*it);
-    pthread_mutex_destroy(&events_list_mutex_);
-  }
+  ~SysInfoLocale();
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
+
+  static const std::string name_;
 
  private:
   explicit SysInfoLocale();
@@ -41,7 +38,6 @@ class SysInfoLocale {
 
   std::string language_;
   std::string country_;
-  pthread_mutex_t events_list_mutex_;
 
 #if defined(GENERIC_DESKTOP)
   static gboolean OnUpdateTimeout(gpointer user_data);

--- a/system_info/system_info_network.cc
+++ b/system_info/system_info_network.cc
@@ -4,6 +4,8 @@
 
 #include "system_info/system_info_network.h"
 
+const std::string SysInfoNetwork::name_ = "NETWORK";
+
 void SysInfoNetwork::Get(picojson::value& error,
                          picojson::value& data) {
   if (!Update(error)) {

--- a/system_info/system_info_network.h
+++ b/system_info/system_info_network.h
@@ -37,16 +37,18 @@ enum SystemInfoNetworkType {
   void METHOD(SENDER, ARG0);
 #endif
 
-class SysInfoNetwork {
+class SysInfoNetwork : public SysInfoObject {
  public:
-  static SysInfoNetwork& GetSysInfoNetwork() {
+  static SysInfoObject& GetInstance() {
     static SysInfoNetwork instance;
     return instance;
   }
   ~SysInfoNetwork();
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
+
+  static const std::string name_;
 
  private:
   explicit SysInfoNetwork();
@@ -57,7 +59,6 @@ class SysInfoNetwork {
   std::string ToNetworkTypeString(SystemInfoNetworkType type);
 
   SystemInfoNetworkType type_;
-  pthread_mutex_t events_list_mutex_;
 
 #if defined(GENERIC_DESKTOP)
   G_CALLBACK_1(OnNetworkManagerCreated, GObject*, GAsyncResult*);

--- a/system_info/system_info_peripheral.h
+++ b/system_info/system_info_peripheral.h
@@ -10,31 +10,28 @@
 #include <vconf-keys.h>
 #endif
 
+#include <string>
+
 #include "common/extension_adapter.h"
 #include "common/picojson.h"
 #include "common/utils.h"
 #include "system_info/system_info_utils.h"
 
-class SysInfoPeripheral {
+class SysInfoPeripheral : public SysInfoObject {
  public:
-  static SysInfoPeripheral& GetSysInfoPeripheral() {
+  static SysInfoObject& GetInstance() {
     static SysInfoPeripheral instance;
     return instance;
   }
-  ~SysInfoPeripheral() {
-    for (SystemInfoEventsList::iterator it = peripheral_events_.begin();
-         it != peripheral_events_.end(); it++)
-      StopListening(*it);
-    pthread_mutex_destroy(&events_list_mutex_);
-  }
+  ~SysInfoPeripheral() {}
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
+
+  static const std::string name_;
 
  private:
-  explicit SysInfoPeripheral() {
-    pthread_mutex_init(&events_list_mutex_, NULL);
-  }
+  explicit SysInfoPeripheral() {}
 
 #if defined(TIZEN_MOBILE)
   void SetWFD(int wfd);
@@ -50,7 +47,6 @@ class SysInfoPeripheral {
   bool is_video_output_;
   int wfd_;
   int hdmi_;
-  pthread_mutex_t events_list_mutex_;
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoPeripheral);
 };

--- a/system_info/system_info_peripheral_desktop.cc
+++ b/system_info/system_info_peripheral_desktop.cc
@@ -4,11 +4,13 @@
 
 #include "system_info/system_info_peripheral.h"
 
+const std::string SysInfoPeripheral::name_ = "PERIPHERAL";
+
 void SysInfoPeripheral::Get(picojson::value& error,
                             picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("Peripheral is not supported on desktop."));
 }
 
-void SysInfoPeripheral::StartListening(ContextAPI* api) { }
-void SysInfoPeripheral::StopListening(ContextAPI* api) { }
+void SysInfoPeripheral::AddListener(ContextAPI* api) { }
+void SysInfoPeripheral::RemoveListener(ContextAPI* api) { }

--- a/system_info/system_info_sim.h
+++ b/system_info/system_info_sim.h
@@ -18,21 +18,16 @@
 #include "common/utils.h"
 #include "system_info/system_info_utils.h"
 
-class SysInfoSim {
+class SysInfoSim : public SysInfoObject {
  public:
-  static SysInfoSim& GetSysInfoSim() {
+  static SysInfoObject& GetInstance() {
     static SysInfoSim instance;
     return instance;
   }
-  ~SysInfoSim() {
-    for (SystemInfoEventsList::iterator it = sim_events_.begin();
-         it != sim_events_.end(); it++)
-      StopListening(*it);
-    pthread_mutex_destroy(&events_list_mutex_);
-  }
+  ~SysInfoSim() {}
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
 
   enum SystemInfoSimState {
     SYSTEM_INFO_SIM_ABSENT = 0,
@@ -53,6 +48,8 @@ class SysInfoSim {
   static void OnSimStateChanged(sim_state_e state, void *user_data);
 #endif
 
+  static const std::string name_;
+
  private:
   explicit SysInfoSim()
       : state_(SYSTEM_INFO_SIM_UNKNOWN),
@@ -62,9 +59,7 @@ class SysInfoSim {
         mcc_(0),
         mnc_(0),
         msin_(""),
-        spn_("") {
-    pthread_mutex_init(&events_list_mutex_, NULL);
-  }
+        spn_("") {}
 
 #if defined(TIZEN_MOBILE)
   bool QuerySIMStatus();
@@ -90,7 +85,6 @@ class SysInfoSim {
   unsigned int mnc_;
   std::string msin_;
   std::string spn_;
-  pthread_mutex_t events_list_mutex_;
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoSim);
 };

--- a/system_info/system_info_sim_desktop.cc
+++ b/system_info/system_info_sim_desktop.cc
@@ -4,11 +4,13 @@
 
 #include "system_info/system_info_sim.h"
 
+const std::string SysInfoSim::name_ = "SIM";
+
 void SysInfoSim::Get(picojson::value& error,
                      picojson::value& data) {
   system_info::SetPicoJsonObjectValue(error, "message",
       picojson::value("SIM is not supported on desktop."));
 }
 
-void SysInfoSim::StartListening(ContextAPI* api) { }
-void SysInfoSim::StopListening(ContextAPI* api) { }
+void SysInfoSim::AddListener(ContextAPI* api) { }
+void SysInfoSim::RemoveListener(ContextAPI* api) { }

--- a/system_info/system_info_storage.h
+++ b/system_info/system_info_storage.h
@@ -16,16 +16,18 @@
 #include "common/utils.h"
 #include "system_info/system_info_utils.h"
 
-class SysInfoStorage {
+class SysInfoStorage : public SysInfoObject {
  public:
-  static SysInfoStorage& GetSysInfoStorage() {
+  static SysInfoObject& GetInstance() {
     static SysInfoStorage instance;
     return instance;
   }
   ~SysInfoStorage();
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
+
+  static const std::string name_;
 
  private:
   explicit SysInfoStorage();
@@ -34,7 +36,6 @@ class SysInfoStorage {
 
   int timeout_cb_id_;
   picojson::value units_;
-  pthread_mutex_t events_list_mutex_;
 
 #if defined(GENERIC_DESKTOP)
   void GetDetails(const std::string& mnt_fsname,

--- a/system_info/system_info_storage_desktop.cc
+++ b/system_info/system_info_storage_desktop.cc
@@ -20,13 +20,11 @@ SysInfoStorage::SysInfoStorage()
     : timeout_cb_id_(0) {
   udev_ = udev_new();
   units_ = picojson::value(picojson::array(0));
-  pthread_mutex_init(&events_list_mutex_, NULL);
 }
 
 SysInfoStorage::~SysInfoStorage() {
   if (udev_)
     udev_unref(udev_);
-  pthread_mutex_destroy(&events_list_mutex_);
 }
 
 bool SysInfoStorage::Update(picojson::value& error) {

--- a/system_info/system_info_storage_mobile.cc
+++ b/system_info/system_info_storage_mobile.cc
@@ -19,13 +19,11 @@ const char* sStorageSDCardPath = "/opt/storage/sdcard";
 SysInfoStorage::SysInfoStorage()
     : timeout_cb_id_(0) {
   units_ = picojson::value(picojson::array(0));
-  pthread_mutex_init(&events_list_mutex_, NULL);
 }
 
 SysInfoStorage::~SysInfoStorage() {
   if (timeout_cb_id_ > 0)
     g_source_remove(timeout_cb_id_);
-  pthread_mutex_destroy(&events_list_mutex_);
 }
 
 bool SysInfoStorage::Update(picojson::value& error) {

--- a/system_info/system_info_utils.h
+++ b/system_info/system_info_utils.h
@@ -14,21 +14,6 @@
 #include "common/extension_adapter.h"
 #include "common/picojson.h"
 
-typedef std::list<ContextAPI*> SystemInfoEventsList;
-
-static SystemInfoEventsList battery_events_;
-static SystemInfoEventsList build_events_;
-static SystemInfoEventsList cellular_events_;
-static SystemInfoEventsList cpu_events_;
-static SystemInfoEventsList device_orientation_events_;
-static SystemInfoEventsList display_events_;
-static SystemInfoEventsList local_events_;
-static SystemInfoEventsList network_events_;
-static SystemInfoEventsList peripheral_events_;
-static SystemInfoEventsList sim_events_;
-static SystemInfoEventsList storage_events_;
-static SystemInfoEventsList wifi_network_events_;
-
 struct AutoLock {
   explicit AutoLock(pthread_mutex_t* m) : m_(m) { pthread_mutex_lock(m_); }
   ~AutoLock() { pthread_mutex_unlock(m_); }
@@ -54,5 +39,42 @@ std::string GetPropertyFromFile(const std::string& file_path,
 bool IsExist(const char* path);
 
 }  // namespace system_info
+
+class SysInfoObject {
+ public:
+  SysInfoObject() {
+    pthread_mutex_init(&listeners_mutex_, NULL);
+  }
+
+  ~SysInfoObject() {
+    AutoLock* lock = new AutoLock(&listeners_mutex_);
+    for (std::list<ContextAPI*>::iterator it = listeners_.begin();
+         it != listeners_.end(); it++) {
+      RemoveListener(*it);
+    }
+    delete lock;
+    pthread_mutex_destroy(&listeners_mutex_);
+  }
+
+  // Get support
+  virtual void Get(picojson::value& error, picojson::value& data) = 0;
+
+  // Listener support
+  virtual void AddListener(ContextAPI* api) = 0;
+  virtual void RemoveListener(ContextAPI* api) {}
+
+  void PostMessageToListeners(const picojson::value& output) {
+    AutoLock lock(&listeners_mutex_);
+    std::string result = output.serialize();
+    for (std::list<ContextAPI*>::iterator it = listeners_.begin();
+         it != listeners_.end(); it++) {
+      (*it)->PostMessage(result.c_str());
+    }
+  }
+
+ protected:
+  pthread_mutex_t listeners_mutex_;
+  std::list<ContextAPI*> listeners_;
+};
 
 #endif  // SYSTEM_INFO_SYSTEM_INFO_UTILS_H_

--- a/system_info/system_info_wifi_network.cc
+++ b/system_info/system_info_wifi_network.cc
@@ -4,6 +4,8 @@
 
 #include "system_info/system_info_wifi_network.h"
 
+const std::string SysInfoWifiNetwork::name_ = "WIFI_NETWORK";
+
 void SysInfoWifiNetwork::Get(picojson::value& error,
                              picojson::value& data) {
   if (!Update(error)) {
@@ -28,11 +30,5 @@ void SysInfoWifiNetwork::SendUpdate() {
       picojson::value("WIFI_NETWORK"));
   system_info::SetPicoJsonObjectValue(output, "data", data);
 
-  std::string result = output.serialize();
-  const char* result_as_cstr = result.c_str();
-  AutoLock lock(&events_list_mutex_);
-  for (SystemInfoEventsList::iterator it = wifi_network_events_.begin();
-    it != wifi_network_events_.end(); it++) {
-    (*it)->PostMessage(result_as_cstr);
-  }
+  PostMessageToListeners(output);
 }

--- a/system_info/system_info_wifi_network.h
+++ b/system_info/system_info_wifi_network.h
@@ -27,16 +27,18 @@
   void METHOD(SENDER, ARG0);
 #endif
 
-class SysInfoWifiNetwork {
+class SysInfoWifiNetwork : public SysInfoObject {
  public:
-  static SysInfoWifiNetwork& GetSysInfoWifiNetwork() {
+  static SysInfoObject& GetInstance() {
     static SysInfoWifiNetwork instance;
     return instance;
   }
   ~SysInfoWifiNetwork();
   void Get(picojson::value& error, picojson::value& data);
-  void StartListening(ContextAPI* api);
-  void StopListening(ContextAPI* api);
+  void AddListener(ContextAPI* api);
+  void RemoveListener(ContextAPI* api);
+
+  static const std::string name_;
 
  private:
   explicit SysInfoWifiNetwork();
@@ -51,7 +53,6 @@ class SysInfoWifiNetwork {
   std::string ipv6_address_;
   std::string ssid_;
   std::string status_;
-  pthread_mutex_t events_list_mutex_;
 
 #if defined(GENERIC_DESKTOP)
   G_CALLBACK_WIFI(OnAccessPointCreated, GObject*, GAsyncResult*);

--- a/system_info/system_info_wifi_network_desktop.cc
+++ b/system_info/system_info_wifi_network_desktop.cc
@@ -22,7 +22,6 @@ SysInfoWifiNetwork::SysInfoWifiNetwork()
       ssid_(""),
       status_("OFF") {
   PlatformInitialize();
-  pthread_mutex_init(&events_list_mutex_, NULL);
 }
 
 void SysInfoWifiNetwork::PlatformInitialize() {
@@ -43,12 +42,8 @@ void SysInfoWifiNetwork::PlatformInitialize() {
       this);
 }
 
-SysInfoWifiNetwork::~SysInfoWifiNetwork() {
-  pthread_mutex_destroy(&events_list_mutex_);
-}
-
-void SysInfoWifiNetwork::StartListening(ContextAPI* api) { }
-void SysInfoWifiNetwork::StopListening(ContextAPI* api) { }
+void SysInfoWifiNetwork::AddListener(ContextAPI* api) { }
+void SysInfoWifiNetwork::RemoveListener(ContextAPI* api) { }
 
 void SysInfoWifiNetwork::SetData(picojson::value& data) {
   system_info::SetPicoJsonObjectValue(data, "status",


### PR DESCRIPTION
Old SystemInfoContext hosts different systeminfo objects as private members(cpu_, display_, etc), 
the issue is we need use lot of if-else to identify which member should called for same functions like 
Get, StartListening and StopListening. 

This change make all system info classes (CPU, DISPLAY, etc.) are inherited from abstract
class SysInfoObject- the interface with above common functions. SystemInfoContext register all system
 info instances in a map during InstancesMapInitialize, thus when there are commands from JavaScript, 
we can enumerate the map instead of using lot of if-else clauses.
