### PR TITLE
[NetworkBearer] Implement the Request and Release route backend

### DIFF
--- a/network_bearer_selection/network_bearer_selection_connection_mobile.cc
+++ b/network_bearer_selection/network_bearer_selection_connection_mobile.cc
@@ -178,6 +178,32 @@ void NetworkBearerSelectionConnection::RequestRouteToHost(
   request_ptr->Failure();
 }
 
+void NetworkBearerSelectionConnection::ReleaseRouteToHost(
+    NetworkBearerSelectionRequest* request) {
+  std::unique_ptr<NetworkBearerSelectionRequest> request_ptr(request);
+
+  if (!is_valid()) {
+    request_ptr->Failure();
+    return;
+  }
+
+  connection_profile_h profile =
+      GetProfileForNetworkType(request_ptr->network_type());
+  if (!profile) {
+    request_ptr->Failure();
+    return;
+  }
+
+  // FIXME(tmpsantos): Tizen runtime implements the "release route" by simply
+  // disconnecting the network interface. We are doing the same here for
+  // compatibility, but it is obviously wrong.
+  if (connection_close_profile(
+          connection_, profile, dummy_callback, NULL) == CONNECTION_ERROR_NONE)
+    request_ptr->Success();
+  else
+    request_ptr->Failure();
+}
+
 connection_profile_h NetworkBearerSelectionConnection::GetProfileForNetworkType(
     NetworkType network_type) {
   // FIXME(tmpsantos): I'm not really sure if we should really map the UNKNOWN

--- a/network_bearer_selection/network_bearer_selection_connection_mobile.h
+++ b/network_bearer_selection/network_bearer_selection_connection_mobile.h
@@ -14,6 +14,7 @@ class NetworkBearerSelectionConnection {
   ~NetworkBearerSelectionConnection();
 
   void RequestRouteToHost(NetworkBearerSelectionRequest* request);
+  void ReleaseRouteToHost(NetworkBearerSelectionRequest* request);
 
   bool is_valid() { return is_valid_; }
 

--- a/network_bearer_selection/network_bearer_selection_context_mobile.cc
+++ b/network_bearer_selection/network_bearer_selection_context_mobile.cc
@@ -36,5 +36,5 @@ void NetworkBearerSelectionContextMobile::OnReleaseRouteToHost(
     return;
   }
 
-  PostMessage(request->cmd(), NO_ERROR, false, request->reply_id());
+  connection_->ReleaseRouteToHost(request);
 }


### PR DESCRIPTION
This series of patches implements the exact behavior we can find at the Tizen Runtime. I don't totally agree with the solution, but it was done in "compatibility mode".
