### PR TITLE
[Time] Truncate TimeDuration length attribute to integer

### DIFF
--- a/time/time_api.js
+++ b/time/time_api.js
@@ -77,7 +77,7 @@ tizen.TimeDuration = function(length, unit) {
   if (!this || this.constructor != tizen.TimeDuration)
     throw new TypeError;
 
-  var length_ = length || 0;
+  var length_ = Math.floor(length) || 0;
   var unit_ = unit || 'MSECS';
 
   Object.defineProperty(this, 'length', {
@@ -85,7 +85,7 @@ tizen.TimeDuration = function(length, unit) {
       return length_; },
     set: function(NewValue) {
       if (NewValue != null)
-        length_ = NewValue; }});
+        length_ = Math.floor(NewValue); }});
 
   Object.defineProperty(this, 'unit', {
     get: function() {
@@ -112,6 +112,7 @@ function getMultiplier(unit) {
 
 function makeMillisecondsDurationObject(length) {
   var dayInMsecs = _hourInMilliseconds * 24;
+  length = Math.floor(length);
 
   if ((length % dayInMsecs) == 0)
     return new tizen.TimeDuration(length / dayInMsecs, 'DAYS');


### PR DESCRIPTION
TimeDuration length attribute in IDL is long long type, it means
that we can accept only integer lengths.

We now use Math.floor() on the length attribute to truncate it.

This patch fixes the TZDate_addDuration_invalidLength TCT test.

Example:

   foo = new tizen.TimeDuration(4.5, "HOURS");

   4.5 -> 4
