### PR TITLE
 [SystemInfo][Display] Correct DPI property wrong type

### DIFF
--- a/system_info/system_info_display.h
+++ b/system_info/system_info_display.h
@@ -56,6 +56,8 @@ class SysInfoDisplay {
 
   int resolution_width_;
   int resolution_height_;
+  unsigned long dots_per_inch_width_; // NOLINT
+  unsigned long dots_per_inch_height_; // NOLINT
   double physical_width_;
   double physical_height_;
   double brightness_;

--- a/system_info/system_info_display_x11.cc
+++ b/system_info/system_info_display_x11.cc
@@ -21,6 +21,8 @@
 SysInfoDisplay::SysInfoDisplay()
     : resolution_width_(0),
       resolution_height_(0),
+      dots_per_inch_width_(0),
+      dots_per_inch_height_(0),
       physical_width_(0.0),
       physical_height_(0.0),
       brightness_(0.0),
@@ -146,8 +148,13 @@ void SysInfoDisplay::SetData(picojson::value& data) {
       picojson::value(physical_height_));
 
   // dpi = N * 25.4 pixels / M inch
+  dots_per_inch_width_ = physical_width_ == 0 ? 0 :
+      static_cast<unsigned long>((resolution_width_ * 25.4) / physical_width_); // NOLINT
+  dots_per_inch_height_ = physical_height_ == 0 ? 0 :
+      static_cast<unsigned long>((resolution_height_ * 25.4) / physical_height_); // NOLINT
+
   system_info::SetPicoJsonObjectValue(data, "dotsPerInchWidth",
-      picojson::value((resolution_width_ * 25.4) / physical_width_));
+      picojson::value(static_cast<double>(dots_per_inch_width_)));
   system_info::SetPicoJsonObjectValue(data, "dotsPerInchHeight",
-      picojson::value((resolution_width_ * 25.4) / physical_width_));
+      picojson::value(static_cast<double>(dots_per_inch_height_)));
 }


### PR DESCRIPTION
The Tizen SystemInfo spec require dotsPerInchWidth and dotsPerInchHeigth as unsigned long, while
it were double that returned. This cause tct-systeminfo-tizen-tests case 173 and case 184 fail.

The fix is simply to convert the value to unsigned long before sending.
