### PR TITLE
[Bluetooth] Only reply Adapter.getDefaultAdapter() when adapter is ready

### DIFF
--- a/bluetooth/bluetooth_context.h
+++ b/bluetooth/bluetooth_context.h
@@ -118,6 +118,8 @@ class BluetoothContext {
 
   void AdapterInfoToValue(picojson::value::object& o);
 
+  void AdapterSendGetDefaultAdapterReply();
+
   ContextAPI* api_;
   std::string discover_callback_id_;
   std::string stop_discovery_callback_id_;


### PR DESCRIPTION
We call ready, when the adapter is in a known state, whether it is ready and
we were able to get all its properties, or we couldn't obtain it (bluetoothd is
not running or the adapter path is not available).

The idea here, is that we should only send the reply to getDefaultAdapter() after we know the state of the adapter, so we delay that response those known points.
