### PR TITLE
Fix the RPM build after da6ee6ec.

### DIFF
--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -34,7 +34,8 @@ BuildRequires: pkgconfig(capi-telephony-sim)
 BuildRequires: pkgconfig(capi-web-favorites)
 BuildRequires: pkgconfig(capi-web-url-download)
 BuildRequires: pkgconfig(dbus-glib-1)
-BuildRequires: pkgconfig(evas) # Evas.h is required by capi-web-favorites.
+# Evas.h is required by capi-web-favorites.
+BuildRequires: pkgconfig(evas)
 BuildRequires: pkgconfig(glib-2.0)
 BuildRequires: pkgconfig(libudev)
 BuildRequires: pkgconfig(message-port)


### PR DESCRIPTION
rpmbuild apparently chokes with comments in the same line as `BuildRequires`:

```
 tizen-extensions-crosswalk:
   nothing provides #
   nothing provides Evas.h
   nothing provides is
   nothing provides required
   nothing provides by
   nothing provides capi-web-favorites.
```
