### PR TITLE
[SystemInfo] Fix the Desktop build.

### DIFF
--- a/system_info/system_info_battery.h
+++ b/system_info/system_info_battery.h
@@ -27,6 +27,7 @@ class SysInfoBattery : public SysInfoObject {
     return instance;
   }
 
+  ~SysInfoBattery();
   void Get(picojson::value& error, picojson::value& data);
   void StartListening();
   void StopListening();

--- a/system_info/system_info_battery_desktop.cc
+++ b/system_info/system_info_battery_desktop.cc
@@ -121,7 +121,7 @@ gboolean SysInfoBattery::OnUpdateTimeout(gpointer user_data) {
         picojson::value("BATTERY"));
     system_info::SetPicoJsonObjectValue(output, "data", data);
 
-    PostMessageToListeners(output);
+    instance->PostMessageToListeners(output);
   }
 
   return TRUE;

--- a/system_info/system_info_battery_mobile.cc
+++ b/system_info/system_info_battery_mobile.cc
@@ -14,6 +14,8 @@ SysInfoBattery::SysInfoBattery()
     : level_(0.0),
       charging_(false) {}
 
+SysInfoBattery::~SysInfoBattery() {}
+
 void SysInfoBattery::Get(picojson::value& error,
                          picojson::value& data) {
   int level = 0;


### PR DESCRIPTION
Fix compilation errors in system_info on Desktop build.

Errors:
../../system_info/system_info_battery_desktop.cc:22:33: error: definition of implicitly-declared ‘SysInfoBattery::~SysInfoBattery()’
../../system_info/system_info_battery_desktop.cc: In static member function ‘static gboolean SysInfoBattery::OnUpdateTimeout(gpointer)’:
../../system_info/system_info_battery_desktop.cc:124:34: error: cannot call member function ‘void SysInfoObject::PostMessageToListeners(const picojson::value&)’ without object
