### PR TITLE
[Download] Fix URL property issue

### DIFF
--- a/download/download_api.js
+++ b/download/download_api.js
@@ -216,10 +216,20 @@ tizen.DownloadRequest = function(url, destination, fileName, networkType) {
     }
   });
 
+  var url_;
+  Object.defineProperty(this, 'url', {
+    get: function() { return this.url_; },
+    set: function(value) {
+      if (value != null) {
+        this.url_ = value;
+      }
+    }
+  });
+  this.url_ = url;
+
   if (!(this instanceof tizen.DownloadRequest)) {
     throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
   }
-  this.url = url;
   this.uid = ++currentUID;
   this.destination = asValidString(destination);
   this.fileName = asValidString(fileName);


### PR DESCRIPTION
The property 'url' of DownloadRequest should not be null, that means setting to null should be ignored, for example:

```
downloadRequest = new tizen.DownloadRequest(url);
downloadRequest.url = null; // downloadRequest.url will not be changed by this statement.
```

Bug: [XWALK-599](https://crosswalk-project.org/jira/browse/XWALK-599)
