### PR TITLE
[Download] Add listener type checking

### DIFF
--- a/download/download_api.js
+++ b/download/download_api.js
@@ -242,7 +242,8 @@ exports.start = function(request, listener) {
     throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
   }
   requests[request.uid] = request;
-  if (typeof listener != 'undefined') {
+  if (listener !== null) {
+    ensureType(listener, 'object');
     exports.setListener(request.uid, listener);
   }
   postMessage({


### PR DESCRIPTION
- `TypeMismatchError` should be thrown when passing an incorrect type of listener to `tizen.download.start(request, listener)`
- It is acceptable to pass null into download start, e.g. `tizen.download.start(request, null);`

Bug: https://crosswalk-project.org/jira/browse/XWALK-601
