### PR TITLE
[Download] Fix network type checking

### DIFF
--- a/download/download_api.js
+++ b/download/download_api.js
@@ -208,10 +208,8 @@ tizen.DownloadRequest = function(url, destination, fileName, networkType) {
   Object.defineProperty(this, 'networkType', {
     get: function() { return this.networkTypeValue; },
     set: function(type) {
-      if (type in AllowDownloadOnNetworkType) {
+      if (type === null || type in AllowDownloadOnNetworkType) {
         this.networkTypeValue = type;
-      } else {
-        throw new tizen.WebAPIException(tizen.WebAPIException.INVALID_VALUES_ERR);
       }
     }
   });


### PR DESCRIPTION
It is ok to set networktype to null, as it is optional.
And no need to throw exception if trying to set invalid value (according to spec).
