### PR TITLE
Add needed SMACK rules.

### DIFF
--- a/packaging/tizen-extensions-crosswalk.rules
+++ b/packaging/tizen-extensions-crosswalk.rules
@@ -1,0 +1,16 @@
+crosswalk::ep system::homedir rx
+crosswalk::ep system::vconf rwx
+crosswalk::ep ail::db r
+crosswalk::ep data-provider-master rw
+crosswalk::ep deviced rw
+crosswalk::ep device::bklight rw
+crosswalk::ep system::media rwx
+crosswalk::ep download-provider w
+crosswalk::ep system::use_internet rw
+crosswalk::ep sound_server rw
+crosswalk::ep stt-server r
+crosswalk::ep pkgmgr::db r
+crosswalk::ep org.tizen.setting rx
+crosswalk::ep dbus rwx
+system::use_internet crosswalk::ep w
+dbus crosswalk::ep rwx

--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -18,6 +18,7 @@ Source3:    %{_bluetooth_demo_package}
 Source4:    %{_examples_package}
 Source5:    %{_system_info_demo_package}
 Source1001: %{name}.manifest
+Source1002: %{name}.rules
 
 BuildRequires: pkgconfig(appcore-common)
 BuildRequires: pkgconfig(bluez)
@@ -79,6 +80,7 @@ Tizen Web APIs system info demo implementation using Crosswalk.
 %setup -q
 
 cp %{SOURCE1001} .
+cp %{SOURCE1002} .
 cp %{SOURCE2} .
 cp %{SOURCE3} .
 cp %{SOURCE4} .
@@ -134,6 +136,9 @@ install -p -m 644 demos/system_info/css/*.css %{buildroot}%{_datarootdir}/%{name
 install -p -m 644 demos/system_info/js/*.js %{buildroot}%{_datarootdir}/%{name}/demos/system_info/js
 install -p -m 644 demos/system_info/images/*.png %{buildroot}%{_datarootdir}/%{name}/demos/system_info/images
 
+# SMACK Rules
+install -m 755 -D %{SOURCE1002} %{buildroot}/etc/smack/accesses.d/%{name}.rules
+
 # register to the package manager
 install -m 644 -D %{_examples_package}.xml %{buildroot}%{_manifestdir}/%{_examples_package}.xml
 install -m 644 -D %{_bluetooth_demo_package}.xml %{buildroot}%{_manifestdir}/%{_bluetooth_demo_package}.xml
@@ -147,6 +152,7 @@ install -p -D %{name}.png %{buildroot}%{_desktop_icondir}/%{_system_info_demo_pa
 # %license LICENSE
 %{_bindir}/%{name}
 %{_libdir}/%{name}/libtizen*.so
+/etc/smack/accesses.d/%{name}.rules
 
 %files -n %{_bluetooth_demo_package}
 %{_bindir}/%{_bluetooth_demo_package}
@@ -172,3 +178,9 @@ install -p -D %{name}.png %{buildroot}%{_desktop_icondir}/%{_system_info_demo_pa
 %{_datarootdir}/%{name}/demos/system_info/css/*.css
 %{_datarootdir}/%{name}/demos/system_info/js/*.js
 %{_datarootdir}/%{name}/demos/system_info/images/*.png
+
+
+%post
+# Load SMACK rules. We do it this way because T-E-C is a special case (not a
+# web app with an app id) and so we don't have to wait for the device to reboot.
+%{_bindir}/smackload /etc/smack/accesses.d/%{name}.rules


### PR DESCRIPTION
This commit install a smack rules for t-e-c "by hand",
instead of using the manifest file. We do it this way because
t-e-c is a "special" case: it is not a web app, thus no real
app id available. It will fallback to the case in which its
ExtensionProcess will run with the default SMACK label
"crosswalk::ep".

This commit makes all extensions work again but Bluetooth,
Download and Network Bearer management, all of which are affected
by the DBus System Bus label bug (please refer to https://github.com/jeez/dbus-bluez4-test).

THIS CAN ONLY BE MERGED AFTER https://github.com/crosswalk-project/crosswalk/pull/1332 has BEEN MERGED!!!
