### PR TITLE
check-coding-style: Pass a path to the find(1) call.

### DIFF
--- a/tools/check-coding-style
+++ b/tools/check-coding-style
@@ -19,7 +19,7 @@ FILTERS="-readability/streams,-runtime/references"
 
 # TODO(cmarcelo): Skipping directories so we can enable style
 # gradually, since it wasn't enforced before.
-cpplint.py --filter="$FILTERS" $(find \
+cpplint.py --filter="$FILTERS" $(find . \
                                ! -path './out*' ! -path './.git*' \
                                ! -path './demos' ! -path './examples' \
                                ! -path './packaging' \


### PR DESCRIPTION
The standard version of the find(1) tool (present in non-Linux operating 
systems, for example) requires a path to be passed to it, so do that to make 
the our script more portable.
