### PR TITLE
[SystemInfo] Added missing symbols for the Desktop build

### DIFF
--- a/system_info/system_info_network_desktop.cc
+++ b/system_info/system_info_network_desktop.cc
@@ -22,6 +22,8 @@ SysInfoNetwork::SysInfoNetwork()
   PlatformInitialize();
 }
 
+SysInfoNetwork::~SysInfoNetwork() {}
+
 void SysInfoNetwork::PlatformInitialize() {
   active_connection_ = "";
   active_device_ = "";

--- a/system_info/system_info_wifi_network_desktop.cc
+++ b/system_info/system_info_wifi_network_desktop.cc
@@ -24,6 +24,8 @@ SysInfoWifiNetwork::SysInfoWifiNetwork()
   PlatformInitialize();
 }
 
+SysInfoWifiNetwork::~SysInfoWifiNetwork() {}
+
 void SysInfoWifiNetwork::PlatformInitialize() {
   active_access_point_ = "";
   active_connection_ = "";


### PR DESCRIPTION
Crosswalk cannot load the SystemInfo library because these two destructors are
missing.
