### PR TITLE
[SystemInfo] add 'SYSTEMINFO_SIM_ACCESS' macro

### DIFF
--- a/common/common.gypi
+++ b/common/common.gypi
@@ -3,6 +3,7 @@
     # If capi-system-power package exists, the host is considered to be Tizen Mobile.
     # Note, the spec file requires this package: BuildRequires: pkgconfig(capi-system-power).
     'extension_host_os%': '<!(pkg-config --exists capi-system-power; if [ $? = 0 ]; then echo mobile; else echo desktop; fi)',
+    'telephony_sim_available%': '<!(pkg-config --exists capi-telephony-sim; if [ $? = 0 ]; then echo true; else echo false; fi)',
     'extension_build_type%': '<(extension_build_type)',
     'extension_build_type%': 'Debug',
   },
@@ -18,6 +19,7 @@
       }],
       ['extension_host_os == "mobile"', { 'defines': ['TIZEN_MOBILE'] } ],
       ['extension_host_os == "desktop"', { 'defines': ['GENERIC_DESKTOP'] } ],
+      ['telephony_sim_available == "true"', { 'defines': ['SYSTEMINFO_SIM_ACCESS'] } ],
       ['extension_build_type== "Debug"', {
         'defines': ['_DEBUG', ],
         'cflags': [ '-O0', '-g', ],

--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -30,7 +30,11 @@ BuildRequires: pkgconfig(capi-system-power)
 BuildRequires: pkgconfig(capi-system-runtime-info)
 BuildRequires: pkgconfig(capi-system-sensor)
 BuildRequires: pkgconfig(capi-system-system-settings)
-BuildRequires: pkgconfig(capi-telephony-sim)
+# For IVI, it doesn't need sim package.
+%bcond_with ivi
+%if !%{with ivi}
+BuildRequires:  pkgconfig(capi-telephony-sim)
+%endif
 BuildRequires: pkgconfig(capi-web-favorites)
 BuildRequires: pkgconfig(capi-web-url-download)
 BuildRequires: pkgconfig(dbus-glib-1)

--- a/system_info/system_info.gyp
+++ b/system_info/system_info.gyp
@@ -15,6 +15,18 @@
             ]
           },
         }],
+        [ 'telephony_sim_available == "true"', {
+          'variables': {
+            'packages': [
+              'capi-telephony-sim',
+            ]
+          },
+          'sources': [
+            'system_info_sim.h',
+            'system_info_sim_desktop.cc',
+            'system_info_sim_mobile.cc',
+          ]
+        }],
         [ 'extension_host_os == "mobile"', {
           'variables': {
             'packages': [
@@ -23,7 +35,6 @@
               'capi-system-info',
               'capi-system-runtime-info',
               'capi-system-sensor',
-              'capi-telephony-sim',
               'pkgmgr-info',
               'vconf',
               'tapi',
@@ -76,9 +87,6 @@
         'system_info_peripheral.h',
         'system_info_peripheral_desktop.cc',
         'system_info_peripheral_mobile.cc',
-        'system_info_sim.h',
-        'system_info_sim_desktop.cc',
-        'system_info_sim_mobile.cc',
         'system_info_storage.cc',
         'system_info_storage.h',
         'system_info_storage_desktop.cc',

--- a/system_info/system_info_instance.cc
+++ b/system_info/system_info_instance.cc
@@ -40,7 +40,9 @@
 #include "system_info/system_info_locale.h"
 #include "system_info/system_info_network.h"
 #include "system_info/system_info_peripheral.h"
+#if defined(SYSTEMINFO_SIM_ACCESS)
 #include "system_info/system_info_sim.h"
+#endif
 #include "system_info/system_info_storage.h"
 #include "system_info/system_info_utils.h"
 #include "system_info/system_info_wifi_network.h"
@@ -67,7 +69,9 @@ void SystemInfoInstance::InstancesMapInitialize() {
   RegisterClass<SysInfoLocale>();
   RegisterClass<SysInfoNetwork>();
   RegisterClass<SysInfoPeripheral>();
+#if defined(SYSTEMINFO_SIM_ACCESS)
   RegisterClass<SysInfoSim>();
+#endif
   RegisterClass<SysInfoStorage>();
   RegisterClass<SysInfoWifiNetwork>();
 }


### PR DESCRIPTION
Add 'SYSTEMINFO_SIM_ACCESS' macro to indicate whether to load sim module.
In IVI device, SIM module is not needed.

Bug ID: https://crosswalk-project.org/jira/browse/XWALK-1018
