### PR TITLE
Add XW_Extension_Permissions.h and XW_Extension_Runtime.h

### DIFF
--- a/common/XW_Extension_Permissions.h
+++ b/common/XW_Extension_Permissions.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_PUBLIC_XW_EXTENSION_PERMISSIONS_H_
+#define XWALK_EXTENSIONS_PUBLIC_XW_EXTENSION_PERMISSIONS_H_
+
+// NOTE: This file and interfaces marked as internal are not considered stable
+// and can be modified in incompatible ways between Crosswalk versions.
+
+#ifndef XWALK_EXTENSIONS_PUBLIC_XW_EXTENSION_H_
+#error "You should include XW_Extension.h before this file"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XW_INTERNAL_PERMISSIONS_INTERFACE_1 \
+    "XW_Internal_PermissionsInterface_1"
+#define XW_INTERNAL_PERMISSIONS_INTERFACE \
+    XW_INTERNAL_PERMISSIONS_INTERFACE_1
+
+//
+// XW_INTERNAL_PERMISSIONS_INTERFACE: provides a way for extensions
+// check if they have the proper permissions for certain APIs.
+//
+
+struct XW_Internal_PermissionsInterface_1 {
+  int (*CheckAPIAccessControl)(XW_Extension extension, const char* api_name);
+  int (*RegisterPermissions)(XW_Extension extension, const char* perm_table);
+};
+
+typedef struct XW_Internal_PermissionsInterface_1
+    XW_Internal_PermissionsInterface;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // XWALK_EXTENSIONS_PUBLIC_XW_EXTENSION_PERMISSIONS_H_

--- a/common/XW_Extension_Runtime.h
+++ b/common/XW_Extension_Runtime.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef XWALK_EXTENSIONS_PUBLIC_XW_EXTENSION_RUNTIME_H_
+#define XWALK_EXTENSIONS_PUBLIC_XW_EXTENSION_RUNTIME_H_
+
+// NOTE: This file and interfaces marked as internal are not considered stable
+// and can be modified in incompatible ways between Crosswalk versions.
+
+#ifndef XWALK_EXTENSIONS_PUBLIC_XW_EXTENSION_H_
+#error "You should include XW_Extension.h before this file"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XW_INTERNAL_RUNTIME_INTERFACE_1 \
+  "XW_Internal_RuntimeInterface_1"
+#define XW_INTERNAL_RUNTIME_INTERFACE \
+  XW_INTERNAL_RUNTIME_INTERFACE_1
+
+//
+// XW_INTERNAL_RUNTIME_INTERFACE: allow extensions to gather information
+// from the runtime.
+//
+
+struct XW_Internal_RuntimeInterface_1 {
+  void (*GetRuntimeVariableString)(XW_Extension extension,
+                                   const char* key,
+                                   char* value,
+                                   size_t value_len);
+};
+
+typedef struct XW_Internal_RuntimeInterface_1
+    XW_Internal_RuntimeInterface;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // XWALK_EXTENSIONS_PUBLIC_XW_EXTENSION_RUNTIME_H_
+

--- a/common/XW_Extension_SyncMessage.h
+++ b/common/XW_Extension_SyncMessage.h
@@ -19,7 +19,9 @@ extern "C" {
 //
 // XW_INTERNAL_SYNC_MESSAGING_INTERFACE: allow JavaScript code to send a
 // synchronous message to extension code and block until response is
-// available.
+// available. The response is made available by calling the SetSyncReply
+// function, that can be done from outside the context of the SyncMessage
+// handler.
 //
 
 #define XW_INTERNAL_SYNC_MESSAGING_INTERFACE_1 \

--- a/common/common.gypi
+++ b/common/common.gypi
@@ -49,6 +49,8 @@
       'XW_Extension.h',
       'XW_Extension_SyncMessage.h',
       'XW_Extension_EntryPoints.h',
+      'XW_Extension_Runtime.h',
+      'XW_Extension_Permissions.h',
       'picojson.h',
       'utils.h',
     ],

--- a/common/extension.cc
+++ b/common/extension.cc
@@ -16,6 +16,8 @@ const XW_CoreInterface* g_core = NULL;
 const XW_MessagingInterface* g_messaging = NULL;
 const XW_Internal_SyncMessagingInterface* g_sync_messaging = NULL;
 const XW_Internal_EntryPointsInterface* g_entry_points = NULL;
+const XW_Internal_RuntimeInterface* g_runtime = NULL;
+const XW_Internal_PermissionsInterface* g_permission = NULL;
 
 bool InitializeInterfaces(XW_GetInterface get_interface) {
   g_core = reinterpret_cast<const XW_CoreInterface*>(
@@ -47,6 +49,20 @@ bool InitializeInterfaces(XW_GetInterface get_interface) {
   if (!g_entry_points) {
     std::cerr << "NOTE: Entry points interface not available in this version "
               << "of Crosswalk, ignoring entry point data for extensions.\n";
+  }
+
+  g_runtime = reinterpret_cast<const XW_Internal_RuntimeInterface*>(
+      get_interface(XW_INTERNAL_RUNTIME_INTERFACE));
+  if (!g_runtime) {
+    std::cerr << "NOTE: runtime interface not available in this version "
+              << "of Crosswalk, ignoring runtime variables for extensions.\n";
+  }
+
+  g_permission = reinterpret_cast<const XW_Internal_PermissionsInterface*>(
+      get_interface(XW_INTERNAL_PERMISSIONS_INTERFACE));
+  if (!g_permission) {
+    std::cerr << "NOTE: permission interface not available in this version "
+      << "of Crosswalk, ignoring permission for extensions.\n";
   }
 
   return true;
@@ -95,6 +111,16 @@ void Extension::SetJavaScriptAPI(const char* api) {
 void Extension::SetExtraJSEntryPoints(const char** entry_points) {
   if (g_entry_points)
     g_entry_points->SetExtraJSEntryPoints(g_xw_extension, entry_points);
+}
+
+bool Extension::RegisterPermissions(const char* perm_table) {
+  if (g_permission)
+    g_pemission(g_xw_extension, perm_table);
+}
+
+bool Extension::CheckAPIAccessControl(const char* api_name) {
+  if (g_permission)
+    g_pemission(g_xw_extension, api_name);
 }
 
 Instance* Extension::CreateInstance() {

--- a/common/extension.h
+++ b/common/extension.h
@@ -19,6 +19,8 @@
 #include "common/XW_Extension.h"
 #include "common/XW_Extension_SyncMessage.h"
 #include "common/XW_Extension_EntryPoints.h"
+#include "common/XW_Extension_Runtime.h"
+#include "common/XW_Extension_Permissions.h"
 
 namespace common {
 
@@ -44,6 +46,10 @@ class Extension {
   void SetExtensionName(const char* name);
   void SetJavaScriptAPI(const char* api);
   void SetExtraJSEntryPoints(const char** entry_points);
+  bool RegisterPermissions(const char* perm_table);
+
+  // This API should be called in the message handler of extension
+  bool CheckAPIAccessControl(const char* api_name);
 
   virtual Instance* CreateInstance();
 


### PR DESCRIPTION
This defines two internal interfaces in Crosswalk to enforce
permission control for extension API and get varibles for runtime.

Also XW_Extension_SyncMessage.h is updated with that in crosswalk

https://crosswalk-project.org/jira/browse/XWALK-1035
