### PR TITLE
[Extension] Fix build issue on size_t not declared

### DIFF
--- a/common/extension.cc
+++ b/common/extension.cc
@@ -115,12 +115,14 @@ void Extension::SetExtraJSEntryPoints(const char** entry_points) {
 
 bool Extension::RegisterPermissions(const char* perm_table) {
   if (g_permission)
-    g_pemission(g_xw_extension, perm_table);
+    return g_permission->RegisterPermissions(g_xw_extension, perm_table);
+  return false;
 }
 
 bool Extension::CheckAPIAccessControl(const char* api_name) {
   if (g_permission)
-    g_pemission(g_xw_extension, api_name);
+    return g_permission->CheckAPIAccessControl(g_xw_extension, api_name);
+  return false;
 }
 
 Instance* Extension::CreateInstance() {

--- a/common/extension.h
+++ b/common/extension.h
@@ -16,6 +16,7 @@
 // script context associated with a frame in the page. These objects serves as
 // storage points for extension specific objects, use them for that.
 
+#include <sys/types.h>
 #include "common/XW_Extension.h"
 #include "common/XW_Extension_SyncMessage.h"
 #include "common/XW_Extension_EntryPoints.h"


### PR DESCRIPTION
The error was introduced the patch 88b8aa029d1699 which is to sync files from crosswalk to t-e-c. The header file <sys/types.h> is forgot to added in t-e-c.
Also function pointer is wrongly used in the patch 88b8aa029d1699.
