### PR TITLE
build desktop, Tizen mobile and IVI profiles properly, 

### DIFF
--- a/application/application.gyp
+++ b/application/application.gyp
@@ -18,7 +18,7 @@
         'application_instance.h',
       ],
       'conditions': [
-        ['extension_host_os == "mobile"', {
+        ['tizen == 1', {
           'includes': [
             '../common/pkg-config.gypi',
           ],

--- a/bluetooth/bluetooth.gyp
+++ b/bluetooth/bluetooth.gyp
@@ -32,7 +32,7 @@
             'defines': ['BLUEZ_4'],
           }
         ],
-        [ 'extension_host_os == "mobile"', {
+        [ 'tizen == 1', {
             'variables': { 'packages': ['capi-network-bluetooth'] },
         }],
       ],

--- a/bluetooth/bluetooth_context.cc
+++ b/bluetooth/bluetooth_context.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <bluetooth.h>
 #endif
 
@@ -10,7 +10,7 @@
 #include "common/picojson.h"
 
 int32_t XW_Initialize(XW_Extension extension, XW_GetInterface get_interface) {
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   int init = bt_initialize();
   if (init != BT_ERROR_NONE)
     g_printerr("\n\nCouldn't initialize Bluetooth module.");

--- a/bluetooth/bluetooth_context_bluez4.cc
+++ b/bluetooth/bluetooth_context_bluez4.cc
@@ -4,7 +4,7 @@
 
 #include "bluetooth/bluetooth_context.h"
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <bluetooth.h>
 #endif
 
@@ -453,7 +453,7 @@ void BluetoothContext::AdapterSetPowered(const picojson::value& msg) {
   bool powered = msg.get("value").get<bool>();
   int error = 0;
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   if (powered)
     error = bt_adapter_enable();
   else
@@ -618,7 +618,7 @@ BluetoothContext::~BluetoothContext() {
 
   g_bus_unwatch_name(name_watch_id_);
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
     bt_deinitialize();
 #endif
 }

--- a/bookmark/bookmark.gyp
+++ b/bookmark/bookmark.gyp
@@ -21,7 +21,7 @@
 
       # Evas.h is used in favorites.h.
       'conditions': [
-        [ 'extension_host_os == "mobile"', {
+        [ 'tizen == 1', {
             'variables': { 'packages': ['capi-web-favorites', 'evas'] },
         }],
       ],

--- a/bookmark/bookmark_instance.h
+++ b/bookmark/bookmark_instance.h
@@ -5,7 +5,7 @@
 #ifndef BOOKMARK_BOOKMARK_INSTANCE_H_
 #define BOOKMARK_BOOKMARK_INSTANCE_H_
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <favorites.h>
 #endif
 

--- a/common/common.gypi
+++ b/common/common.gypi
@@ -1,8 +1,7 @@
 {
   'variables': {
-    # If capi-system-power package exists, the host is considered to be Tizen Mobile.
-    # Note, the spec file requires this package: BuildRequires: pkgconfig(capi-system-power).
-    'extension_host_os%': '<!(pkg-config --exists capi-system-power; if [ $? = 0 ]; then echo mobile; else echo desktop; fi)',
+    'extension_host_os%': 'desktop',
+    'tizen%': '0',
     'telephony_sim_available%': '<!(pkg-config --exists capi-telephony-sim; if [ $? = 0 ]; then echo true; else echo false; fi)',
     'extension_build_type%': '<(extension_build_type)',
     'extension_build_type%': 'Debug',
@@ -18,7 +17,9 @@
         'sources/': [['exclude', '_desktop\\.cc$|desktop/']],
         'includes/': [['exclude', '_desktop\\.gypi$|desktop/']],
       }],
+      ['tizen == 1', { 'defines': ['TIZEN'] } ],
       ['extension_host_os == "mobile"', { 'defines': ['TIZEN_MOBILE'] } ],
+      ['extension_host_os == "ivi"', { 'defines': ['TIZEN_IVI'] } ],
       ['extension_host_os == "desktop"', { 'defines': ['GENERIC_DESKTOP'] } ],
       ['telephony_sim_available == "true"', { 'defines': ['SYSTEMINFO_SIM_ACCESS'] } ],
       ['extension_build_type== "Debug"', {

--- a/download/download.gyp
+++ b/download/download.gyp
@@ -15,7 +15,7 @@
         'download_utils.h',
       ],
       'conditions': [
-        ['extension_host_os=="mobile"', {
+        ['tizen == 1', {
           'includes': [
             '../common/pkg-config.gypi',
           ],

--- a/network_bearer_selection/network_bearer_selection.gyp
+++ b/network_bearer_selection/network_bearer_selection.gyp
@@ -20,7 +20,7 @@
         'network_bearer_selection_request.h',
       ],
       'conditions': [
-        [ 'extension_host_os=="mobile"', {
+        [ 'tizen == 1', {
           'includes': [
             '../common/pkg-config.gypi',
           ],

--- a/notification/notification.gyp
+++ b/notification/notification.gyp
@@ -31,7 +31,7 @@
         [ 'extension_host_os == "desktop"', {
             'variables': { 'packages': ['libnotify'] },
         }],
-        [ 'extension_host_os == "mobile"', {
+        [ 'tizen == 1', {
             'variables': { 'packages': ['notification'] },
         }],
       ],

--- a/notification/notification_extension.cc
+++ b/notification/notification_extension.cc
@@ -7,7 +7,7 @@
 #if defined(GENERIC_DESKTOP)
 #include <libnotify/notify.h>
 #include "notification/notification_instance_desktop.h"
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
 #include "notification/notification_instance_mobile.h"
 #endif
 
@@ -38,7 +38,7 @@ NotificationExtension::~NotificationExtension() {}
 common::Instance* NotificationExtension::CreateInstance() {
 #if defined(GENERIC_DESKTOP)
   return new NotificationInstanceDesktop;
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   return new NotificationInstanceMobile(&manager_);
 #endif
   return NULL;

--- a/notification/notification_extension.h
+++ b/notification/notification_extension.h
@@ -7,7 +7,7 @@
 
 #include "common/extension.h"
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include "notification/mobile/notification_manager.h"
 #endif
 
@@ -20,7 +20,7 @@ class NotificationExtension : public common::Extension {
   // common::Extension implementation.
   virtual common::Instance* CreateInstance();
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   NotificationManager manager_;
 #endif
 };

--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -35,8 +35,7 @@ BuildRequires: pkgconfig(capi-system-runtime-info)
 BuildRequires: pkgconfig(capi-system-sensor)
 BuildRequires: pkgconfig(capi-system-system-settings)
 # For IVI, it doesn't need sim package.
-%bcond_with ivi
-%if !%{with ivi}
+%if "%{profile}" != "ivi"
 BuildRequires: pkgconfig(capi-telephony-sim)
 %endif
 BuildRequires: pkgconfig(capi-web-favorites)
@@ -101,15 +100,23 @@ cp %{SOURCE5} .
 %build
 
 export GYP_GENERATORS='make'
-./tools/gyp/gyp \
---depth=.       \
--Dextension_build_type=Debug   \
+GYP_OPTIONS="--depth=. -Dtizen=1 -Dextension_build_type=Debug"
+
 %if %{with wayland}
--Ddisplay_type=wayland \
+GYP_OPTIONS="$GYP_OPTIONS -Ddisplay_type=wayland"
 %else
--Ddisplay_type=x11 \
+GYP_OPTIONS="$GYP_OPTIONS -Ddisplay_type=x11"
 %endif
-tizen-wrt.gyp
+
+%if "%{profile}" == "mobile"
+GYP_OPTIONS="$GYP_OPTIONS -Dextension_host_os=mobile"
+%else
+%if "%{profile}" == "ivi"
+GYP_OPTIONS="$GYP_OPTIONS -Dextension_host_os=ivi"
+%endif
+%endif
+
+./tools/gyp/gyp $GYP_OPTIONS tizen-wrt.gyp
 
 make %{?_smp_mflags}
 

--- a/power/power.gyp
+++ b/power/power.gyp
@@ -24,7 +24,7 @@
         '../common/pkg-config.gypi',
       ],
       'conditions': [
-        ['extension_host_os=="mobile"', {
+        ['tizen == 1', {
           'variables': {
             'packages': [
               'glib-2.0',

--- a/power/power_extension.cc
+++ b/power/power_extension.cc
@@ -6,7 +6,7 @@
 
 #if defined(GENERIC_DESKTOP)
 #include "power/power_instance_desktop.h"
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
 #include "power/power_instance_mobile.h"
 #endif
 
@@ -27,7 +27,7 @@ PowerExtension::~PowerExtension() {}
 common::Instance* PowerExtension::CreateInstance() {
 #if defined(GENERIC_DESKTOP)
   return new PowerInstanceDesktop;
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   return new PowerInstanceMobile(&power_event_source_);
 #endif
   return NULL;

--- a/power/power_extension.h
+++ b/power/power_extension.h
@@ -7,7 +7,7 @@
 
 #include "common/extension.h"
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include "power/mobile/power_event_source.h"
 #endif
 
@@ -20,7 +20,7 @@ class PowerExtension : public common::Extension {
   // common::Extension implementation.
   virtual common::Instance* CreateInstance();
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   PowerEventSource power_event_source_;
 #endif
 };

--- a/system_info/system_info.gyp
+++ b/system_info/system_info.gyp
@@ -27,7 +27,7 @@
             'system_info_sim_mobile.cc',
           ]
         }],
-        [ 'extension_host_os == "mobile"', {
+        [ 'tizen == 1', {
           'variables': {
             'packages': [
               'appcore-common',

--- a/system_info/system_info_battery.h
+++ b/system_info/system_info_battery.h
@@ -8,7 +8,7 @@
 #include <glib.h>
 #include <libudev.h>
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <vconf.h>
 #include <vconf-keys.h>
 #endif
@@ -44,7 +44,7 @@ class SysInfoBattery : public SysInfoObject {
 
   udev* udev_;
   int timeout_cb_id_;
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   void UpdateLevel(double level);
   void UpdateCharging(bool charging);
   static void OnLevelChanged(keynode_t* node, void* user_data);

--- a/system_info/system_info_build_mobile.cc
+++ b/system_info/system_info_build_mobile.cc
@@ -5,7 +5,7 @@
 #include "system_info/system_info_build.h"
 
 #include <stdlib.h>
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <system_info.h>
 #endif
 

--- a/system_info/system_info_cellular_network.h
+++ b/system_info/system_info_cellular_network.h
@@ -5,7 +5,7 @@
 #ifndef SYSTEM_INFO_SYSTEM_INFO_CELLULAR_NETWORK_H_
 #define SYSTEM_INFO_SYSTEM_INFO_CELLULAR_NETWORK_H_
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <vconf-keys.h>
 #include <vconf.h>
 #endif
@@ -33,7 +33,7 @@ class SysInfoCellularNetwork : public SysInfoObject {
  private:
   explicit SysInfoCellularNetwork() {}
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   void SendUpdate();
   void SetData(picojson::value& data);
 

--- a/system_info/system_info_device_orientation.h
+++ b/system_info/system_info_device_orientation.h
@@ -5,7 +5,7 @@
 #ifndef SYSTEM_INFO_SYSTEM_INFO_DEVICE_ORIENTATION_H_
 #define SYSTEM_INFO_SYSTEM_INFO_DEVICE_ORIENTATION_H_
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <sensor.h>
 #include <vconf.h>
 #endif
@@ -42,7 +42,7 @@ class SysInfoDeviceOrientation : public SysInfoObject {
       : status_(PORTRAIT_PRIMARY),
         sensorHandle_(0) {}
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   void SetStatus();
   bool SetAutoRotation();
   void SendUpdate();

--- a/system_info/system_info_display_wayland.cc
+++ b/system_info/system_info_display_wayland.cc
@@ -13,7 +13,7 @@
 
 #if defined(GENERIC_DESKTOP)
   #define ACPI_BACKLIGHT_DIR "/sys/class/backlight/acpi_video0"
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   #define ACPI_BACKLIGHT_DIR "/sys/class/backlight/psb-bl"
 #else
   #error "Unsupported platform"

--- a/system_info/system_info_display_x11.cc
+++ b/system_info/system_info_display_x11.cc
@@ -12,7 +12,7 @@
 
 #if defined(GENERIC_DESKTOP)
   #define ACPI_BACKLIGHT_DIR "/sys/class/backlight/acpi_video0"
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   #define ACPI_BACKLIGHT_DIR "/sys/class/backlight/psb-bl"
 #else
   #error "Unsupported platform"

--- a/system_info/system_info_instance.cc
+++ b/system_info/system_info_instance.cc
@@ -21,7 +21,7 @@
 
 #include <dlfcn.h>
 #include <stdlib.h>
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <pkgmgr-info.h>
 #include <sensors.h>
 #include <system_info.h>
@@ -166,7 +166,7 @@ void SystemInfoInstance::HandleSyncMessage(const char* message) {
 void SystemInfoInstance::HandleGetCapabilities() {
   picojson::value::object o;
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   bool b;
   int i;
   char* s = NULL;

--- a/system_info/system_info_locale.h
+++ b/system_info/system_info_locale.h
@@ -5,7 +5,7 @@
 #ifndef SYSTEM_INFO_SYSTEM_INFO_LOCALE_H_
 #define SYSTEM_INFO_SYSTEM_INFO_LOCALE_H_
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <vconf.h>
 #include <vconf-keys.h>
 #endif
@@ -43,7 +43,7 @@ class SysInfoLocale : public SysInfoObject {
   static gboolean OnUpdateTimeout(gpointer user_data);
 
   int timeout_cb_id_;
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   static void OnCountryChanged(keynode_t* node, void* user_data);
   static void OnLanguageChanged(keynode_t* node, void* user_data);
   void Update();

--- a/system_info/system_info_network.h
+++ b/system_info/system_info_network.h
@@ -7,7 +7,7 @@
 
 #if defined(GENERIC_DESKTOP)
 #include <gio/gio.h>
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
 #include <net_connection.h>
 #endif
 #include <string>
@@ -80,7 +80,7 @@ class SysInfoNetwork : public SysInfoObject {
   std::string active_connection_;
   std::string active_device_;
   guint device_type_;
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   bool GetNetworkType();
   static void OnTypeChanged(connection_type_e type, void* user_data);
 

--- a/system_info/system_info_peripheral.h
+++ b/system_info/system_info_peripheral.h
@@ -5,7 +5,7 @@
 #ifndef SYSTEM_INFO_SYSTEM_INFO_PERIPHERAL_H_
 #define SYSTEM_INFO_SYSTEM_INFO_PERIPHERAL_H_
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <vconf.h>
 #include <vconf-keys.h>
 #endif
@@ -33,7 +33,7 @@ class SysInfoPeripheral : public SysInfoObject {
  private:
   explicit SysInfoPeripheral() {}
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   void SetWFD(int wfd);
   void SetHDMI(int hdmi);
 

--- a/system_info/system_info_sim.h
+++ b/system_info/system_info_sim.h
@@ -5,7 +5,7 @@
 #ifndef SYSTEM_INFO_SYSTEM_INFO_SIM_H_
 #define SYSTEM_INFO_SYSTEM_INFO_SIM_H_
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <errno.h>
 #include <sim.h>
 #include <stdlib.h>
@@ -41,7 +41,7 @@ class SysInfoSim : public SysInfoObject {
     SYSTEM_INFO_SIM_UNKNOWN
   };
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   typedef int (*SIMGetterFunction1)(char** out);
   typedef int (*SIMGetterFunction2)(char** out1, char** out2);
 
@@ -61,7 +61,7 @@ class SysInfoSim : public SysInfoObject {
         msin_(""),
         spn_("") {}
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
   bool QuerySIMStatus();
   bool QuerySIM(SIMGetterFunction1 getter,
                 std::string& member,

--- a/system_info/system_info_storage.h
+++ b/system_info/system_info_storage.h
@@ -45,7 +45,7 @@ class SysInfoStorage : public SysInfoObject {
   std::string GetDevPathFromMountPath(const std::string& mnt_path);
 
   struct udev* udev_;
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   bool GetInternal(picojson::value& error, picojson::value& unit);
   bool GetMMC(picojson::value& error, picojson::value& unit);
 #endif

--- a/system_info/system_info_wifi_network.h
+++ b/system_info/system_info_wifi_network.h
@@ -7,7 +7,7 @@
 
 #if defined(GENERIC_DESKTOP)
 #include <gio/gio.h>
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
 #include <net_connection.h>
 #endif
 #include <string>
@@ -88,7 +88,7 @@ class SysInfoWifiNetwork : public SysInfoObject {
   std::string active_device_;
   std::string ipv6_config_;
   unsigned int ip_address_desktop_;
-#elif defined(TIZEN_MOBILE)
+#elif defined(TIZEN)
   bool GetIPv4Address();
   bool GetIPv6Address();
   bool GetSignalStrength();

--- a/system_setting/system_setting.gyp
+++ b/system_setting/system_setting.gyp
@@ -18,7 +18,7 @@
         '../common/extension.cc',
       ],
       'conditions': [
-        ['extension_host_os=="mobile"', {
+        ['tizen == 1', {
           'includes': [
             '../common/pkg-config.gypi',
           ],

--- a/time/time.gyp
+++ b/time/time.gyp
@@ -24,7 +24,7 @@
         '../common/extension.cc',
       ],
       'conditions': [
-        [ 'extension_host_os == "mobile"', {
+        [ 'tizen == 1', {
             'variables': { 'packages': ['vconf'] },
         }],
       ],

--- a/time/time_instance.cc
+++ b/time/time_instance.cc
@@ -4,7 +4,7 @@
 
 #include "time/time_instance.h"
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
 #include <vconf.h>
 #endif
 
@@ -329,7 +329,7 @@ UnicodeString TimeInstance::getDateTimeFormat(DateTimeFormatType type,
     if (type != TIME_FORMAT)
       skeleton = UDAT_YEAR_MONTH_WEEKDAY_DAY;
 
-#if defined(TIZEN_MOBILE)
+#if defined(TIZEN)
     int value = 0;
     if (vconf_get_int(VCONFKEY_REGIONFORMAT_TIME1224, &value) == -1)
       skeleton += "hhmmss";

--- a/tizen-wrt.gyp
+++ b/tizen-wrt.gyp
@@ -19,7 +19,7 @@
         'tizen/tizen.gyp:*',
       ],
       'conditions': [
-        [ 'extension_host_os == "mobile"', {
+        [ 'tizen == 1', {
           'dependencies': [
             'application/application.gyp:*',
             'download/download.gyp:*',
@@ -34,7 +34,7 @@
       'type': 'none',
 
       'conditions': [
-        [ 'extension_host_os == "mobile"', {
+        [ 'tizen == 1', {
           'actions': [
             {
               'variables': {


### PR DESCRIPTION
replace TIZEN_MOBILE definitions for TIZEN

By default, extension_host_os is set to "desktop". If a tizen repository is present, TIZEN will be defined to 1. In addition, TIZEN_IVI is defined for IVI and TIZEN_MOBILE is defined for mobile. All extensions which should work on all Tizen profiles, should use TIZEN, others should use the more specific TIZEN_MOBILE and TIZEN_IVI. Made changes in the spec file, checking on the %profile variable for "ivi", "mobile" (defined in build.xml and propagated to build.conf).

Before, TIZEN_MOBILE was assumed to work with IVI, considering mobile equal to IVI, which is not the case with every extension. 
