### PR TITLE
enabled building callhistory extension

### DIFF
--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -38,6 +38,10 @@ BuildRequires: pkgconfig(capi-system-system-settings)
 %if "%{profile}" != "ivi"
 BuildRequires: pkgconfig(capi-telephony-sim)
 %endif
+%if "%{profile}" == "mobile"
+BuildRequires: pkgconfig(contacts-service2)
+BuildRequires: pkgconfig(libpcrecpp)
+%endif
 BuildRequires: pkgconfig(capi-web-favorites)
 BuildRequires: pkgconfig(capi-web-url-download)
 BuildRequires: pkgconfig(dbus-glib-1)

--- a/tizen-wrt.gyp
+++ b/tizen-wrt.gyp
@@ -22,8 +22,9 @@
         [ 'tizen == 1', {
           'dependencies': [
             'application/application.gyp:*',
-            'download/download.gyp:*',
             'bookmark/bookmark.gyp:*',
+            'callhistory/callhistory.gyp:*',
+            'download/download.gyp:*',
             'messageport/messageport.gyp:*',
           ],
         }],


### PR DESCRIPTION
Builds in Mobile. Doesn't affect IVI builds.
