### PR TITLE
[TIZEN] : Fix build for common profile

### DIFF
--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -35,10 +35,8 @@ BuildRequires: pkgconfig(capi-system-runtime-info)
 BuildRequires: pkgconfig(capi-system-sensor)
 BuildRequires: pkgconfig(capi-system-system-settings)
 # For IVI, it doesn't need sim package.
-%if "%{profile}" != "ivi"
-BuildRequires: pkgconfig(capi-telephony-sim)
-%endif
 %if "%{profile}" == "mobile"
+BuildRequires: pkgconfig(capi-telephony-sim)
 BuildRequires: pkgconfig(contacts-service2)
 BuildRequires: pkgconfig(libpcrecpp)
 %endif
@@ -104,20 +102,12 @@ cp %{SOURCE5} .
 %build
 
 export GYP_GENERATORS='make'
-GYP_OPTIONS="--depth=. -Dtizen=1 -Dextension_build_type=Debug"
+GYP_OPTIONS="--depth=. -Dtizen=1 -Dextension_build_type=Debug -Dextension_host_os=%{profile}"
 
 %if %{with wayland}
 GYP_OPTIONS="$GYP_OPTIONS -Ddisplay_type=wayland"
 %else
 GYP_OPTIONS="$GYP_OPTIONS -Ddisplay_type=x11"
-%endif
-
-%if "%{profile}" == "mobile"
-GYP_OPTIONS="$GYP_OPTIONS -Dextension_host_os=mobile"
-%else
-%if "%{profile}" == "ivi"
-GYP_OPTIONS="$GYP_OPTIONS -Dextension_host_os=ivi"
-%endif
 %endif
 
 ./tools/gyp/gyp $GYP_OPTIONS tizen-wrt.gyp


### PR DESCRIPTION
- Use %profile as name of extension_host_os
- capi-telephony-sim is only for mobile profile

BUG=https://crosswalk-project.org/jira/browse/XWALK-1254

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
