### PR TITLE
Fix build for x64 arch

### DIFF
--- a/content/content_instance.cc
+++ b/content/content_instance.cc
@@ -309,7 +309,7 @@ void ContentItem::init(media_info_h handle) {
   if (media_info_get_rating(handle, &i) == MEDIA_CONTENT_ERROR_NONE)
     setRating(i);
 
-  uint64_t ll;
+  unsigned long long ll; // NOLINT
   if (media_info_get_size(handle, &ll) == MEDIA_CONTENT_ERROR_NONE)
     setSize(ll);
 


### PR DESCRIPTION
media_info_get_size waits unsigned long long not uint64_t
even if it seems to be the same in 32 bits arch.

=> int media_info_get_size(media_info_h media, unsigned long long *size)

log:

[   27s] content/content_instance.cc: In member function 'void ContentItem::init(media_info_h)':
[   27s] content/content_instance.cc:313:38: error: invalid conversion from 'uint64_t\* {aka long unsigned int_}' to 'long long unsigned int_' [-fpermissive]
[   27s]    if (media_info_get_size(handle, &ll) == MEDIA_CONTENT_ERROR_NONE)
[   27s]                                       ^

BUG=https://crosswalk-project.org/jira/browse/XWALK-1346

Followied the /usr/include/stdint.h we have
# if __WORDSIZE == 64

typedef unsigned long int   uint64_t;
# else

**extension**
typedef unsigned long long int  uint64_t;
# endif

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
