### PR TITLE
[Tizen] Content API - Part 3

### DIFF
--- a/content/content.gyp
+++ b/content/content.gyp
@@ -13,12 +13,14 @@
       },
       'sources': [
         'content_api.js',
-        'content_extension.h',
         'content_extension.cc',
-        'content_instance.h',
+        'content_extension.h',
+        'content_filter.cc',
+        'content_filter.h',
         'content_instance.cc',
-        '../common/extension.h',
+        'content_instance.h',
         '../common/extension.cc',
+        '../common/extension.h',
       ],
       'includes': [
         '../common/pkg-config.gypi',

--- a/content/content_api.js
+++ b/content/content_api.js
@@ -60,6 +60,37 @@ function Content(id, name, type, mimeType, title, contentURI, thumnailURIs, rele
   });
 }
 
+function ContentAudio(obj, album, genres, artists, composer, copyright, bitrate, trackNumber, duration) {
+  Object.defineProperties(obj, {
+    'album': { writable: false, value: album, enumerable: true },
+    'genres': { writable: false, value: genres, enumerable: true },
+    'artists': { writable: false, value: artists, enumerable: true },
+    'composer': { writable: false, value: composer, enumerable: true },
+    'copyright': { writable: false, value: copyright, enumerable: true },
+    'bitrate': { writable: false, value: bitrate, enumerable: true },
+    'trackNumber': { writable: false, value: trackNumber, enumerable: true },
+    'duration': { writable: false, value: duration, enumerable: true },
+  });
+}
+
+function ContentImage(obj, width, height, orientation) {
+  Object.defineProperties(obj, {
+    'width': { writable: false, value: width, enumerable: true },
+    'height': { writable: false, value: height, enumerable: true },
+    'orientation': { writable: false, value: orientation, enumerable: true },
+  });
+}
+
+function ContentVideo(obj, album, artists, duration, width, height) {
+  Object.defineProperties(obj, {
+    'album': { writable: false, value: album, enumerable: true },
+    'artists': { writable: false, value: artists, enumerable: true },
+    'duration': { writable: false, value: duration, enumerable: true },
+    'width': { writable: false, value: width, enumerable: true },
+    'height': { writable: false, value: height, enumerable: true },
+  });
+}
+
 function ContentManager() {
 }
 
@@ -120,6 +151,30 @@ ContentManager.prototype.find = function(onsuccess, onerror, directoryId, filter
               content.size,
               content.description,
               content.rating);
+
+          if (content.type == "AUDIO") {
+            ContentAudio(jsonContent,
+                content.album,
+                content.genres,
+                content.artists,
+                content.composer,
+                content.copyright,
+                content.bitrate,
+                content.trackNumber,
+                content.duration);
+          } else if (content.type == "IMAGE") {
+            ContentImage(jsonContent,
+                content.width,
+                content.height,
+                content.orientation);
+          } else if (content.type == "VIDEO") {
+            ContentImage(jsonContent,
+                content.album,
+                content.artists,
+                content.duration,
+                content.width,
+                content.height);
+          }
           contents.push(jsonContent);
         }     
         onsuccess(contents);

--- a/content/content_filter.cc
+++ b/content/content_filter.cc
@@ -1,0 +1,121 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/content_filter.h"
+#include <map>
+
+ContentFilter& ContentFilter::instance() {
+  static ContentFilter instance;
+  return instance;
+}
+
+namespace {
+// TODO(spoussa): add lazy loading
+const std::map<std::string, std::string>& attributeNameMap = {
+  {"id",                    "MEDIA_ID"},
+  {"type",                  "MEDIA_TYPE"},
+  {"mimeType",              "MEDIA_MIME_TYPE"},
+  {"name",                  "MEDIA_DISPLAY_NAME"},
+  {"title",                 "MEDIA_TITLE"},
+  {"contentURI",            "MEDIA_PATH"},
+  {"thumbnailURIs",         "MEDIA_THUMBNAIL_PATH"},
+  {"description",           "MEDIA_DESCRIPTION"},
+  {"rating",                "MEDIA_RATING"},
+  {"createdDate",           "MEDIA_ADDED_TIME"},
+  {"releaseDate",           "MEDIA_DATETAKEN"},
+  {"modifiedDate",          "MEDIA_MODIFIED_TIME"},
+  {"geolocation.latitude",  "MEDIA_LATITUDE"},
+  {"geolocation.longitude", "MEDIA_LONGITUDE"},
+  {"duration",              "MEDIA_DURATION"},
+  {"album",                 "MEDIA_ALBUM"},
+  {"artists",               "MEDIA_ARTIST"},
+  {"width",                 "MEDIA_WIDTH"},
+  {"height",                "MEDIA_HEIGHT"},
+  {"genres",                "MEDIA_GENRE"},
+  {"size",                  "MEDIA_SIZE"},
+};
+
+const std::map<std::string, std::string>& opMap = {
+  {"EXACTLY",    " = "},
+  {"FULLSTRING", " = "},
+  {"CONTAINS",   " LIKE "},
+  {"STARTSWITH", " LIKE "},
+  {"ENDSWITH",   " LIKE "},
+  {"EXISTS",     " IS NOT NULL "},
+};
+}  // namespace
+
+// TODO(spoussa): we only support the attribute filter now.
+// Range and composite filters are missing.
+std::string ContentFilter::convert(const picojson::value& jsonFilter) {
+  std::string attributeName = jsonFilter.get("attributeName").to_str();
+  std::string matchFlag = jsonFilter.get("matchFlag").to_str();
+  std::string matchValue = jsonFilter.get("matchValue").to_str();
+
+#ifdef DEBUG
+  std::cout << "Filter IN: " <<
+      attributeName << " " << matchFlag << " " << matchValue << std::endl;
+#endif
+
+  std::string query;
+  if (attributeName.empty() || matchFlag.empty()) {
+    std::cerr <<
+        "Filter ERR: attribute or match flag missing" << std::endl;
+    return query;
+  }
+
+  std::map<std::string, std::string>::const_iterator it;
+  it = attributeNameMap.find(attributeName);
+  if (it == attributeNameMap.end()) {
+    std::cerr << "Filter ERR: unknown attributeName " <<
+        attributeName << std::endl;
+    return query;
+  }
+  std::string lValue = it->second;
+
+  it = opMap.find(matchFlag);
+  if (it == attributeNameMap.end()) {
+    std::cerr << "Filter ERR: unknown matchFlag " << matchFlag << std::endl;
+    return query;
+  }
+  std::string op = it->second;
+
+  // Tizen requires this weird mapping on type
+  if (attributeName == "type") {
+    if (matchValue == "IMAGE")
+      matchValue = "0";
+    else if (matchValue == "VIDEO")
+      matchValue = "1";
+    else if (matchValue == "AUDIO")
+      matchValue = "3";
+    else if (matchValue == "OTHER") {
+      matchValue = "4";
+    } else {
+      std::cerr << "Filter ERR: unknown media type " << matchValue << std::endl;
+      return query;
+    }
+  }
+
+  const std::string STR_QUOTE("'");
+  const std::string STR_PERCENT("%");
+  std::string rValue;
+  if (matchFlag == "CONTAINS")
+    rValue = STR_QUOTE + STR_PERCENT + matchValue + STR_PERCENT + STR_QUOTE;
+  else if (matchFlag == "STARTSWITH")
+    rValue = STR_QUOTE + matchValue + STR_PERCENT + STR_QUOTE;
+  else if (matchFlag == "ENDSWITH")
+    rValue = STR_QUOTE + STR_PERCENT + matchValue + STR_QUOTE;
+  else if (matchFlag == "FULLSTRING")
+    rValue = STR_QUOTE + matchValue + STR_QUOTE + " COLLATE NOCASE ";
+  else if (matchFlag == "EXISTS")
+    rValue = "";
+  else
+    rValue = STR_QUOTE + matchValue + STR_QUOTE;
+
+  query = lValue + op + rValue;
+#ifdef DEBUG
+  std::cout << "Filter OUT: " << query << std::endl;
+#endif
+  return query;
+}

--- a/content/content_filter.h
+++ b/content/content_filter.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CONTENT_CONTENT_FILTER_H_
+#define CONTENT_CONTENT_FILTER_H_
+
+#include <string>
+#include "common/picojson.h"
+
+// TODO(spoussa): Once more filters are impllemnted this class will enhance.
+class ContentFilter {
+ public:
+  static ContentFilter& instance();
+  std::string convert(const picojson::value &jsonFilter);
+
+ private:
+  ContentFilter() {}
+};
+
+#endif  // CONTENT_CONTENT_FILTER_H_

--- a/content/content_instance.cc
+++ b/content/content_instance.cc
@@ -3,8 +3,11 @@
 // found in the LICENSE file.
 
 #include "content/content_instance.h"
+#include "content/content_filter.h"
 
 #include <media_content.h>
+#include <media_filter.h>
+
 #include <assert.h>
 
 #include <iostream>
@@ -13,6 +16,7 @@
 #include "common/picojson.h"
 
 namespace {
+const std::string STR_FILTER("filter");
 std::string pathToURI(const std::string path) {
   static std::string scheme("file://");
 
@@ -48,6 +52,9 @@ void ContentInstance::HandleMessage(const char* message) {
     std::cerr << "Ignoring message.\n";
     return;
   }
+#ifdef DEBUG
+  std::cout << "HandleMessage: " << message << std::endl;
+#endif
   std::string cmd = v.get("cmd").to_str();
   if (cmd == "ContentManager.getDirectories") {
     HandleGetDirectoriesRequest(v);
@@ -98,7 +105,7 @@ void ContentInstance::HandleGetDirectoriesRequest(const picojson::value& msg) {
   if (media_folder_foreach_folder_from_db(NULL,
           mediaFolderCallback,
           reinterpret_cast<void*>(&folderList)) != MEDIA_CONTENT_ERROR_NONE) {
-    std::cerr << "media_folder_get_folder_count_from_db: error\n";
+    std::cerr << "media_folder_foreach_folder_from_db: error" << std::endl;
   } else {
     HandleGetDirectoriesReply(msg, &folderList);
   }
@@ -118,8 +125,7 @@ void ContentInstance::HandleGetDirectoriesReply(const picojson::value& msg,
     o["directoryURI"] = picojson::value(folder->directoryURI());
     o["title"] = picojson::value(folder->title());
     o["storageType"] = picojson::value(folder->storageType());
-    o["modifiedDate"] =
-      picojson::value(static_cast<double>(folder->modifiedDate()));
+    o["modifiedDate"] = picojson::value(folder->modifiedDate());
 
     folders.push_back(picojson::value(o));
   }
@@ -146,14 +152,31 @@ bool ContentInstance::mediaFolderCallback(media_folder_h handle,
 
 void ContentInstance::HandleFindRequest(const picojson::value& msg) {
   ContentItemList itemList;
-  if (media_info_foreach_media_from_db(NULL,
+  filter_h filterHandle = NULL;
+
+  ContentFilter& filter = ContentFilter::instance();
+  if (msg.contains(STR_FILTER)) {
+    picojson::value filterValue = msg.get(STR_FILTER);
+    if (!filterValue.is<picojson::null>()) {
+      std::string condition = filter.convert(msg.get(STR_FILTER));
+      if (media_filter_create(&filterHandle) == MEDIA_CONTENT_ERROR_NONE)
+        media_filter_set_condition(filterHandle,
+            condition.c_str(), MEDIA_CONTENT_COLLATE_DEFAULT);
+    }
+  }
+
+  if (media_info_foreach_media_from_db(filterHandle,
       mediaInfoCallback,
       reinterpret_cast<ContentFolderList*>(&itemList))
       != MEDIA_CONTENT_ERROR_NONE) {
-    std::cerr << "media_info_foreach_media_from_db: error\n";
+    std::cerr << "media_info_foreach_media_from_db: error" << std::endl;
   } else {
     HandleFindReply(msg, &itemList);
   }
+
+  if (filterHandle != NULL && media_filter_destroy(filterHandle)
+      != MEDIA_CONTENT_ERROR_NONE)
+    std::cerr << "media_filter_destroy failed" << std::endl;
 }
 
 void ContentInstance::HandleFindReply(
@@ -174,18 +197,55 @@ void ContentInstance::HandleFindReply(
     o["mimeType"] = picojson::value(item->mimeType());
     o["title"] = picojson::value(item->title());
     o["contentURI"] = picojson::value(item->contentURI());
-    o["thumbnailURIs"] = picojson::value(item->thumbnailURIs());
-    o["releaseDate"] =
-      picojson::value(static_cast<double>(item->releaseDate()));
+    picojson::value::array uris;
+    uris.push_back(picojson::value(item->thumbnailURIs()));
+    o["thumbnailURIs"] = picojson::value(uris);
+    o["releaseDate"] = picojson::value(item->releaseDate());
     o["modifiedDate"] =
-      picojson::value(static_cast<double>(item->modifiedDate()));
+      picojson::value(item->modifiedDate());
     o["size"] = picojson::value(static_cast<double>(item->size()));
     o["description"] = picojson::value(item->description());
     o["rating"] = picojson::value(static_cast<double>(item->rating()));
 
+    if (item->type() == "AUDIO") {
+      o["album"] = picojson::value(item->album());
+      picojson::value::array genres;
+      genres.push_back(picojson::value(item->genres()));
+      o["genres"] = picojson::value(genres);
+      picojson::value::array artists;
+      artists.push_back(picojson::value(item->artists()));
+      o["artists"] = picojson::value(artists);
+      picojson::value::array composers;
+      composers.push_back(picojson::value(item->composer()));
+      o["composers"] = picojson::value(composers);
+      o["copyright"] = picojson::value(item->copyright());
+      o["bitrate"] = picojson::value(static_cast<double>(item->bitrate()));
+      o["trackNumber"] = picojson::value(
+          static_cast<double>(item->trackNumber()));
+      o["duration"] = picojson::value(static_cast<double>(item->duration()));
+    } else if (item->type() == "IMAGE") {
+      o["width"] = picojson::value(static_cast<double>(item->width()));
+      o["height"] = picojson::value(static_cast<double>(item->height()));
+      o["orientation"] = picojson::value(item->orientation());
+    } else if (item->type() == "VIDEO") {
+      o["album"] = picojson::value(item->album());
+      picojson::value::array artists;
+      artists.push_back(picojson::value(item->artists()));
+      o["artists"] = picojson::value(artists);
+      o["duration"] = picojson::value(static_cast<double>(item->duration()));
+      o["width"] = picojson::value(static_cast<double>(item->width()));
+      o["height"] = picojson::value(static_cast<double>(item->height()));
+    }
+
+    picojson::value v(o);
+
     items.push_back(picojson::value(o));
   }
   picojson::value value(items);
+#ifdef DEBUG
+  std::cout << "JSON reply: " << std::endl <<
+     value.serialize().c_str() << std::endl;
+#endif
   PostAsyncSuccessReply(msg, value);
 }
 
@@ -239,18 +299,20 @@ void ContentFolder::init(media_folder_h handle) {
 
   if (media_folder_get_modified_time(
       handle, &date) == MEDIA_CONTENT_ERROR_NONE) {
-    setModifiedDate(date);
+    char tmp[26];
+    ctime_r(&date, tmp);
+    setModifiedDate(tmp);
   }
 }
 
 #ifdef DEBUG
 void ContentFolder::print(void) {
-  std::cout << "ID: " << getID() << std::endl;
-  std::cout << "URI: " << getDirectoryURI() << std::endl;
-  std::cout << "Title: " << getTitle() << std::endl;
-  std::cout << "Type: " << getStorageType() << std::endl;
+  std::cout << "ID: " << id() << std::endl;
+  std::cout << "URI: " << directoryURI() << std::endl;
+  std::cout << "Title: " << title() << std::endl;
+  std::cout << "Type: " << storageType() << std::endl;
   char pc[26];
-  time_t time = getModifiedDate();
+  time_t time = modifiedDate();
   std::cout << "Date: " << ctime_r(&time, pc) << std::endl;
 }
 #endif
@@ -290,7 +352,7 @@ void ContentItem::init(media_info_h handle) {
 
   if (media_info_get_thumbnail_path(handle,
       &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
-    setThumbnailURIs(pc);
+    setThumbnailURIs(pathToURI(pc));
     free(pc);
   }
 
@@ -302,7 +364,9 @@ void ContentItem::init(media_info_h handle) {
 
   time_t date;
   if (media_info_get_modified_time(handle, &date) == MEDIA_CONTENT_ERROR_NONE) {
-    setModifiedDate(date);
+    char tmp[26];
+    ctime_r(&date, tmp);
+    setModifiedDate(tmp);
   }
 
   int i = 0;
@@ -315,32 +379,172 @@ void ContentItem::init(media_info_h handle) {
 
   media_content_type_e type;
   if (media_info_get_media_type(handle, &type) == MEDIA_CONTENT_ERROR_NONE) {
-    if (type == MEDIA_CONTENT_TYPE_IMAGE)
+    if (type == MEDIA_CONTENT_TYPE_IMAGE) {
       setType("IMAGE");
-    else if (type == MEDIA_CONTENT_TYPE_VIDEO)
+
+      image_meta_h image;
+      if (media_info_get_image(handle, &image) == MEDIA_CONTENT_ERROR_NONE) {
+        if (image_meta_get_width(image, &i) == MEDIA_CONTENT_ERROR_NONE)
+          setWidth(i);
+
+        if (image_meta_get_height(image, &i) == MEDIA_CONTENT_ERROR_NONE)
+          setHeight(i);
+
+        // TODO(spoussa): coordinates do not return sensible values...
+        double d;
+        if (media_info_get_latitude(handle, &d) == MEDIA_CONTENT_ERROR_NONE)
+          setLatitude(d);
+
+       if (media_info_get_longitude(handle, &d) == MEDIA_CONTENT_ERROR_NONE)
+          setLongitude(d);
+
+        media_content_orientation_e orientation;
+        if (image_meta_get_orientation(image, &orientation)
+            == MEDIA_CONTENT_ERROR_NONE) {
+          std::string result("");
+
+          switch (orientation) {
+            case 0:
+            case 1: result = "NORMAL"; break;
+            case 2: result = "FLIP_HORIZONTAL"; break;
+            case 3: result = "ROTATE_180"; break;
+            case 4: result = "FLIP_VERTICAL"; break;
+            case 5: result = "TRANSPOSE"; break;
+            case 6: result = "ROTATE_90"; break;
+            case 7: result = "TRANSVERSE"; break;
+            case 8: result = "ROTATE_270"; break;
+            default: result = "Unknown"; break;
+          }
+          setOrientation(result);
+        }
+        image_meta_destroy(image);
+      }
+    } else if (type == MEDIA_CONTENT_TYPE_VIDEO) {
       setType("VIDEO");
-    else if (type == MEDIA_CONTENT_TYPE_MUSIC)
+
+      video_meta_h video;
+      if (media_info_get_video(handle, &video) == MEDIA_CONTENT_ERROR_NONE) {
+        if (video_meta_get_recorded_date(video,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          setReleaseDate(pc);
+          free(pc);
+        }
+
+        if (video_meta_get_album(video,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          setAlbum(pc);
+          free(pc);
+        }
+
+        if (video_meta_get_artist(video,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          setArtists(pc);
+          free(pc);
+        }
+
+        if (video_meta_get_width(video, &i) == MEDIA_CONTENT_ERROR_NONE) {
+          setWidth(i);
+        }
+
+        if (video_meta_get_height(video, &i) == MEDIA_CONTENT_ERROR_NONE) {
+          setHeight(i);
+        }
+
+        if (video_meta_get_duration(video, &i) == MEDIA_CONTENT_ERROR_NONE) {
+          setDuration(i);
+        }
+
+        video_meta_destroy(video);
+      }
+    } else if (type == MEDIA_CONTENT_TYPE_MUSIC) {
       setType("AUDIO");
-    else if (type == MEDIA_CONTENT_TYPE_OTHERS)
+
+      audio_meta_h audio;
+      if (media_info_get_audio(handle, &audio) == MEDIA_CONTENT_ERROR_NONE) {
+        if (audio_meta_get_recorded_date(audio,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          setReleaseDate(pc);
+          free(pc);
+        }
+
+        if (audio_meta_get_album(audio,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          setAlbum(pc);
+          free(pc);
+        }
+
+        if (audio_meta_get_artist(audio,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          setArtists(pc);
+          free(pc);
+        }
+
+        if (audio_meta_get_composer(audio,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          setComposer(pc);
+          free(pc);
+        }
+
+        if (audio_meta_get_duration(audio, &i) == MEDIA_CONTENT_ERROR_NONE)
+          setDuration(i);
+
+        if (audio_meta_get_copyright(audio,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          setCopyright(pc);
+          free(pc);
+        }
+
+        if (audio_meta_get_track_num(audio,
+            &pc) == MEDIA_CONTENT_ERROR_NONE && pc) {
+          i = atoi(pc);
+          setTrackNumber(i);
+          free(pc);
+        }
+
+        if (audio_meta_get_bit_rate(audio, &i) == MEDIA_CONTENT_ERROR_NONE)
+          setBitrate(i);
+      }
+      audio_meta_destroy(audio);
+    } else if (type == MEDIA_CONTENT_TYPE_OTHERS) {
       setType("OTHER");
+    }
   }
 }
 
 #ifdef DEBUG
 void ContentItem::print(void) {
   std::cout << "----" << std::endl;
-  std::cout << "ID: " << getID() << std::endl;
-  std::cout << "Name: " << getName() << std::endl;
-  std::cout << "Type: " << getType() << std::endl;
-  std::cout << "MIME: " << getMimeType() << std::endl;
-  std::cout << "Title: " << getTitle() << std::endl;
-  std::cout << "URI: " << getContentURI() << std::endl;
-  std::cout << "ThumbnailURIs: " << getThumbnailURIs() << std::endl;
-  char pc[26];
-  time_t time = getModifiedDate();
-  std::cout << "Modified: " << ctime_r(&time, pc);
-  std::cout << "Size: " << getSize() << std::endl;
-  std::cout << "Description: " << getDescription() << std::endl;
-  std::cout << "Rating: " << getRating() << std::endl;
+  std::cout << "ID: " << id() << std::endl;
+  std::cout << "Name: " << name() << std::endl;
+  std::cout << "Type: " << type() << std::endl;
+  std::cout << "MIME: " << mimeType() << std::endl;
+  std::cout << "Title: " << title() << std::endl;
+  std::cout << "URI: " << contentURI() << std::endl;
+  std::cout << "ThumbnailURIs: " << thumbnailURIs() << std::endl;
+  std::cout << "Modified: " << modifiedDate();
+  std::cout << "Size: " << size() << std::endl;
+  std::cout << "Description: " << description() << std::endl;
+  std::cout << "Rating: " << rating() << std::endl;
+  if (type() == "AUDIO") {
+    std::cout << "Release Date: " << releaseDate() << std::endl;
+    std::cout << "Album: " << album() << std::endl;
+    std::cout << "Genres: " << genres() << std::endl;
+    std::cout << "Artists: " << artists() << std::endl;
+    std::cout << "Composer: " << composer() << std::endl;
+    std::cout << "Copyright: " << copyright() << std::endl;
+    std::cout << "Bitrate: " << bitrate() << std::endl;
+    std::cout << "Track num: " << trackNumber() << std::endl;
+    std::cout << "Duration: " << duration() << std::endl;
+  } else if (type() == "IMAGE") {
+    std::cout << "Width/Height: " << width() << "/" << height() << std::endl;
+    std::cout << "Latitude: " << latitude() << std::endl;
+    std::cout << "Longitude: " << longitude() << std::endl;
+    std::cout << "Orientation: " << orientation() << std::endl;
+  } else if (type() == "VIDEO") {
+    std::cout << "Album: " << album() << std::endl;
+    std::cout << "Artists: " << artists() << std::endl;
+    std::cout << "Duration: " << duration() << std::endl;
+    std::cout << "Width/Height: " << width() << "/" << height() << std::endl;
+  }
 }
 #endif

--- a/content/content_instance.h
+++ b/content/content_instance.h
@@ -54,24 +54,20 @@ class ContentInstance : public common::Instance {
 
 class ContentFolder {
  public:
-  ContentFolder() {
-    modifiedDate_ = { 0 };
-  }
-  ~ContentFolder() {}
-
   void init(media_folder_h handle);
 
   // Getters & Getters
-  std::string id() const { return id_; }
+  const std::string& id() const { return id_; }
   void setID(const std::string& id) { id_ = id; }
-  std::string directoryURI() const { return directoryURI_; }
+  const std::string& directoryURI() const { return directoryURI_; }
   void setDirectoryURI(const std::string& uri) { directoryURI_ = uri; }
-  std::string title() const { return title_; }
+  const std::string& title() const { return title_; }
   void setTitle(const std::string& title) { title_ = title; }
-  std::string storageType() const { return storageType_; }
+  const std::string& storageType() const { return storageType_; }
   void setStorageType(const std::string& type) { storageType_ = type; }
-  time_t modifiedDate() const { return modifiedDate_; }
-  void setModifiedDate(time_t modifiedDate) { modifiedDate_ = modifiedDate; }
+  const std::string& modifiedDate() const { return modifiedDate_; }
+  void setModifiedDate(const std::string& modifiedDate) {
+    modifiedDate_ = modifiedDate; }
 
 #ifdef DEBUG
   void print(void);
@@ -82,46 +78,72 @@ class ContentFolder {
   std::string directoryURI_;
   std::string title_;
   std::string storageType_;
-  time_t modifiedDate_;
+  std::string modifiedDate_;
 };
 
 class ContentItem {
  public:
-  ContentItem() {
-    releaseDate_ = { 0 };
-    modifiedDate_ = { 0 };
-    size_ = 0;
-    rating_ = 0;
-  }
-  ~ContentItem() {}
+  ContentItem() : size_(0), rating_(0), bitrate_(0), trackNumber_(0),
+      duration_(0), width_(0), height_(0), latitude_(0), longitude_(0)
+  {}
 
   void init(media_info_h handle);
 
   // Getters & Setters
-  std::string id() const { return id_; }
+  const std::string& id() const { return id_; }
   void setID(const std::string& id) { id_ = id; }
-  const std::string name() const { return name_; }
+  const std::string& name() const { return name_; }
   void setName(const std::string& name) { name_ = name; }
-  std::string type() const { return type_; }
+  const std::string& type() const { return type_; }
   void setType(const std::string& type) { type_ = type;}
-  std::string mimeType() const { return mimeType_; }
+  const std::string& mimeType() const { return mimeType_; }
   void setMimeType(const std::string& mimeType) { mimeType_ = mimeType; }
-  std::string title() const { return title_; }
+  const std::string& title() const { return title_; }
   void setTitle(const std::string& title) { title_ = title;}
-  std::string contentURI() const { return contentURI_; }
+  const std::string& contentURI() const { return contentURI_; }
   void setContentURI(const std::string& uri) { contentURI_ = uri; }
-  std::string thumbnailURIs() const { return thumbnailURIs_; }
+  const std::string& thumbnailURIs() const { return thumbnailURIs_; }
   void setThumbnailURIs(const std::string& uris) { thumbnailURIs_ = uris; }
-  time_t releaseDate() const { return releaseDate_; }
-  void setReleaseDate(time_t releaseDate) { releaseDate_ = releaseDate; }
-  time_t modifiedDate() const { return modifiedDate_; }
-  void setModifiedDate(time_t modifiedDate) { modifiedDate_ = modifiedDate; }
+  const std::string& releaseDate() const { return releaseDate_; }
+  void setReleaseDate(const std::string releaseDate) {
+    releaseDate_ = releaseDate; }
+  const std::string& modifiedDate() const { return modifiedDate_; }
+  void setModifiedDate(const std::string& modifiedDate) {
+    modifiedDate_ = modifiedDate; }
   uint64_t size() const { return size_; }
   void setSize(const uint64_t size) { size_ = size; }
-  std::string description() const { return description_; }
+  const std::string& description() const { return description_; }
   void setDescription(const std::string& desc) { description_ = desc; }
   uint64_t rating() const { return rating_; }
   void setRating(uint64_t rating) { rating_ = rating; }
+  // type = AUDIO and VIDEO
+  const std::string& album() const { return album_; }
+  void setAlbum(const std::string& album) { album_ = album;}
+  const std::string& genres() const { return genres_; }
+  void setGenres(const std::string& genres) { genres_ = genres;}
+  const std::string& artists() const { return artists_; }
+  void setArtists(const std::string& artists) { artists_ = artists;}
+  const std::string& composer() const { return composer_; }
+  void setComposer(const std::string& composer) { composer_ = composer;}
+  const std::string& copyright() const { return copyright_; }
+  void setCopyright(const std::string& copyright) { copyright_ = copyright;}
+  uint64_t bitrate() const { return rating_; }
+  void setBitrate(uint64_t bitrate) { bitrate_ = bitrate; }
+  uint64_t trackNumber() const { return bitrate_; }
+  void setTrackNumber(uint64_t num) { trackNumber_ = num; }
+  int duration() const { return duration_; }
+  void setDuration(int duration) { duration_ = duration; }
+  // type = IMAGE
+  uint64_t width() const { return width_; }
+  void setWidth(uint64_t width) { width_ = width; }
+  uint64_t height() const { return height_; }
+  void setHeight(uint64_t height) { height_ = height; }
+  const std::string& orientation() const { return orientation_; }
+  void setOrientation(const std::string& orintatin) {orientation_ = orintatin;}
+  double latitude() const { return latitude_; }
+  void setLatitude(double latitude) { latitude_ = latitude; }
+  double longitude() const { return latitude_; }
+  void setLongitude(double latitude) { latitude_ = latitude; }
 
 #ifdef DEBUG
   void print(void);
@@ -135,11 +157,28 @@ class ContentItem {
   std::string title_;
   std::string contentURI_;
   std::string thumbnailURIs_;
-  time_t releaseDate_;
-  time_t modifiedDate_;
+  std::string releaseDate_;
+  std::string modifiedDate_;
   uint64_t size_;
   std::string description_;
   uint64_t rating_;
+
+  // type = AUDIO and VIDEO
+  std::string album_;
+  std::string genres_;
+  std::string artists_;
+  std::string composer_;
+  std::string copyright_;
+  uint64_t bitrate_;
+  uint16_t trackNumber_;
+  int duration_;
+
+  // type = IMAGE
+  uint64_t width_;
+  uint64_t height_;
+  double latitude_;
+  double longitude_;
+  std::string orientation_;
 };
 
 class ContentFolderList {

--- a/examples/content.html
+++ b/examples/content.html
@@ -5,37 +5,49 @@
 
 <h1>Tizen Content API</h1>
 <body>
-<button onClick="handleUpdate()">Update</button>
-<button onClick="handleUpdateBatch()">Update Batch</button>
+<button onClick="handleCleanConsole()">Clean</button>
 <button onClick="handleGetDirectories()">Get Directories</button>
 <button onClick="handleFind()">Find</button>
 <button onClick="handleScanFile()">Scan File</button>
+
+<div>
+  <h2>Attribute Filter</h2>
+  <select id="attribute-name">
+    <option value="type">type</option>
+    <option value="mimeType">mime</option>
+    <option value="title">title</option>
+    <option value="contentURI">uri</option>
+    <option value="thumbnailURIs">thumbnails</option>
+    <option value="size">size</option>
+    <option value="rating">rating</option>
+    <option value="artists">artist</option>
+    <option value="duration">duration</option>
+    <option value="width">width</option>
+    <option value="height">height</option>
+  </select>
+  <select id="match-flag">
+    <option value="EXACTLY">EXACTLY</option>
+    <option value="FULLSTRING">FULLSTRING</option>
+    <option value="CONTAINS">CONTAINS</option>
+    <option value="STARTSWITH">STARTSWITH</option>
+    <option value="ENDSWITH">ENDSWITH</option>
+    <option value="EXISTS">EXISTS</option>
+  </select>
+  <input id="match-value" type="text">
+
+</div>
 
 <pre id="console"></pre>
 <script src="js/js-test-pre.js"></script>
 <script>
 
-function handleUpdate()
+function handleCleanConsole()
 {
-  try {
-    debug('tizen.content.update:');
-    tizen.content.update();
-  }
-  catch (err) {
-    debug(err.name);
-  }
+  var el = document.getElementById("console");
+  while (el.firstChild)
+    el.removeChild(el.firstChild);
 }
 
-function handleUpdateBatch()
-{
-  try {
-    debug('tizen.content.updateBatch:');
-    tizen.content.updateBatch();
-  }
-  catch (err) {
-    debug(err.name);
-  }
-}
 function handleGetDirectories()
 {
   try {
@@ -55,16 +67,28 @@ function handleGetDirectories()
 }
 function handleFind()
 {
+  var filter = null;
+
+  var e = document.getElementById("attribute-name");
+  var attributeName = e.options[e.selectedIndex].value;
+  e = document.getElementById("match-flag");
+  var matchFlag = e.options[e.selectedIndex].value;
+  var matchValue = document.getElementById('match-value').value;
+
+  debug("Filter: " + attributeName + ' ' + matchFlag + ' ' + matchValue);
+  if (matchValue != "" || matchFlag == "EXISTS")
+    filter = new tizen.AttributeFilter(attributeName, matchFlag, matchValue);
+
   try {
     debug('tizen.content.find:');
     tizen.content.find(function(items) {
       for (var i = 0; i < items.length; i++) {
-        debug(items[i].title + ', ' + items[i].mimeType + ', ' + items[i].contentURI);
+        debug(items[i].title + ', ' + items[i].mimeType);
       }    
     }, 
     function(err) {
       debug('find: error');
-    });
+    }, null, filter);
   }
   catch (err) {
     debug(err.name);


### PR DESCRIPTION
Added support for Tizen filters (AttributeFilter only). The rest (Range and Composite) are coming later.

Added also support for media type specific attributes for audio, video and image types.

Changed some types to more convenient ones f.ex timestamp to string.

Added filtering features to examples/content.html test page.
