### PR TITLE
[download] Throw TypeError when Constructor called as function

### DIFF
--- a/download/download_api.js
+++ b/download/download_api.js
@@ -226,7 +226,7 @@ tizen.DownloadRequest = function(url, destination, fileName, networkType) {
   this.url_ = url;
 
   if (!(this instanceof tizen.DownloadRequest)) {
-    throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
+    throw new TypeError;
   }
   this.uid = ++currentUID;
   this.destination = asValidString(destination);


### PR DESCRIPTION
This aligns with other Tizen API's behavior in such case.

BUG=https://crosswalk-project.org/jira/browse/xwalk-959
