### PR TITLE
[Permission] make CheckAPIAccessControl as static method

### DIFF
--- a/common/extension.h
+++ b/common/extension.h
@@ -53,7 +53,7 @@ class Extension {
   bool RegisterPermissions(const char* perm_table);
 
   // This API should be called in the message handler of extension
-  bool CheckAPIAccessControl(const char* api_name);
+  static bool CheckAPIAccessControl(const char* api_name);
 
   virtual Instance* CreateInstance();
 


### PR DESCRIPTION
- In order to make t-e-c instance can call permission API directly,
  adjust the method to static. After that, message handlers of each
  instance can call common::Extension::CheckAPIAccessControl to check
  whether current extension has the permssion to access.
