### PR TITLE
[Application] Add application context, kill, launch and events support

### DIFF
--- a/application/application.cc
+++ b/application/application.cc
@@ -1,0 +1,69 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "application/application.h"
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <utility>
+
+#include "application/application_context.h"
+#include "application/application_extension_utils.h"
+#include "application/application_information.h"
+
+Application::Application(const std::string& pkg_id)
+    : pkg_id_(pkg_id) {
+}
+
+Application::~Application() {
+}
+
+ApplicationInformation Application::GetAppInfo() {
+  if (app_id_.empty() && !RetrieveAppId())
+    // Return an invalid ApplicationInformation by passing an empty app ID.
+    return ApplicationInformation("");
+
+  return ApplicationInformation(app_id_);
+}
+
+ApplicationContext Application::GetAppContext() {
+  return ApplicationContext(std::to_string(getpid()));
+}
+
+picojson::value* Application::Exit() {
+  // TODO(xiang): calls "Terminate" method of running app object on session bus.
+  std::cerr << "ASSERT NOT IMPLEMENTED.\n";
+  return CreateResultMessage();
+}
+
+picojson::value* Application::Hide() {
+  // TODO(xiang): calls "Hide" method of running app object on session bus.
+  std::cerr << "ASSERT NOT IMPLEMENTED.\n";
+  return CreateResultMessage();
+}
+
+const std::string Application::Serialize() {
+  ApplicationInformation app_info = GetAppInfo();
+  ApplicationContext app_ctx = GetAppContext();
+
+  std::unique_ptr<picojson::value> result;
+  if (!app_info.IsValid() || !app_ctx.IsValid()) {
+    result.reset(CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR));
+  } else {
+    picojson::object obj;
+    obj["appInfo"] = app_info.Value();
+    obj["appContext"] = app_ctx.Value();
+    result.reset(CreateResultMessage(obj));
+  }
+  return result->serialize();
+}
+
+bool Application::RetrieveAppId() {
+  app_id_ = ApplicationInformation::PkgIdToAppId(pkg_id_);
+  if (app_id_.empty()) {
+    std::cerr << "Can't translate app package ID to application ID.\n";
+    return false;
+  }
+  return true;
+}

--- a/application/application.gyp
+++ b/application/application.gyp
@@ -9,13 +9,20 @@
       'sources': [
         '../common/extension.cc',
         '../common/extension.h',
+        'application.cc',
+        'application.h',
         'application_api.js',
+        'application_context.cc',
+        'application_context.h',
         'application_extension.cc',
         'application_extension.h',
+        'application_extension_utils.h',
         'application_information.cc',
         'application_information.h',
         'application_instance.cc',
         'application_instance.h',
+        'application_manager.cc',
+        'application_manager.h',
       ],
       'conditions': [
         ['tizen == 1', {
@@ -24,6 +31,8 @@
           ],
           'variables': {
             'packages': [
+              'appcore-common',
+              'capi-appfw-app-manager',
               'capi-appfw-package-manager',
               'pkgmgr',
               'pkgmgr-info',

--- a/application/application.h
+++ b/application/application.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef APPLICATION_APPLICATION_H_
+#define APPLICATION_APPLICATION_H_
+
+#include <memory>
+#include <string>
+
+#include "common/picojson.h"
+
+class ApplicationContext;
+class ApplicationInformation;
+
+// This class will represent the current application running this extension.
+class Application {
+ public:
+  explicit Application(const std::string& pkg_id);
+  ~Application();
+
+  ApplicationInformation GetAppInfo();
+  ApplicationContext GetAppContext();
+
+  picojson::value* Exit();
+  picojson::value* Hide();
+
+  const std::string Serialize();
+
+ private:
+  bool RetrieveAppId();
+
+  std::string app_id_;
+  std::string pkg_id_;
+};
+
+#endif  // APPLICATION_APPLICATION_H_

--- a/application/application_api.js
+++ b/application/application_api.js
@@ -2,41 +2,130 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-var callbacks = {};
-var callbackId = 0;
-var cbKey = '_callback';
+var asyncCallbacks = {
+  _next_id: 0,
+  _callbacks: {},
+  key: '_callback',
 
-function setupCallback(callback) {
-  var id = ++callbackId;
-  callbacks[id] = callback;
-  return id;
-}
+  // Return a callback ID number which will be contained by the native message.
+  setup: function(callback) {
+    var id = ++this._next_id;
+    this._callbacks[id] = callback;
+    return id;
+  },
 
-// This callback will dispatch message to different handlers by callbackId.
+  dispatch: function(m) {
+    var id = m[this.key];
+    var callback = this._callbacks[id];
+    callback.call(null, m);
+    delete this._callbacks[id];
+  }
+};
+
+var appInfoEventCallbacks = {
+  _next_id: 0,
+  _callbacks: [],
+  key: '_appInfoEventCallback',
+
+  // Return a callback ID number which can be unregistered later.
+  addCallback: function(callback) {
+    if (!this._callbacks.length) {
+      var result = sendSyncMessage({ cmd: 'RegisterAppInfoEvent' });
+      if (result.error != null)
+        throw new tizen.WebAPIException(result.error);
+    }
+
+    var id = ++this._next_id;
+    this._callbacks.push({func: callback, id: id});
+    return id;
+  },
+
+  removeCallback: function(id) {
+    for (var i = 0, len = this._callbacks.length; i < len; i++) {
+      if (id === this._callbacks[i].id)
+        break;
+    }
+    if (i == len)
+      throw new tizen.WebAPIException(tizen.WebAPIException.NOT_FOUND_ERR);
+
+    this._callbacks.splice(i, 1);
+    if (!this._callbacks.length) {
+      var result = sendSyncMessage({ cmd: 'UnregisterAppInfoEvent' });
+      if (result.error != null)
+        throw new tizen.WebAPIException(result.error);
+    }
+  },
+
+  dispatch: function(m) {
+    var callbacks = this._callbacks.slice();
+    for (var i = 0, len = callbacks.length; i < len; i++)
+      callbacks[i].func.call(null, m);
+  }
+};
+
 extension.setMessageListener(function(msg) {
   var m = JSON.parse(msg);
-  var callback = callbacks[m[cbKey]];
-  delete callbacks[m[cbKey]];
-  callback(m);
+  if (typeof m[asyncCallbacks.key] === 'number') {
+    asyncCallbacks.dispatch(m);
+  } else {
+    if (m[asyncCallbacks.key] === appInfoEventCallbacks.key)
+      appInfoEventCallbacks.dispatch(m);
+    else
+      console.error('unexpected message received' + msg);
+  }
 });
 
 // Post async message to extension with callbackId saved. The extension will return
 // a message with the same callbackId to the callback set in setMessageListener.
-var postMessage = function(msg, callbackId) {
-  msg[cbKey] = callbackId;
+function postMessage(msg, callbackId) {
+  msg[asyncCallbacks.key] = callbackId;
   extension.postMessage(JSON.stringify(msg));
-};
+}
 
-var sendSyncMessage = function(msg) {
+function sendSyncMessage(msg) {
   return JSON.parse(extension.internal.sendSyncMessage(JSON.stringify(msg)));
+}
+
+function defineReadOnlyProperty(object, key, value) {
+  Object.defineProperty(object, key, {
+    enumerable: true,
+    writable: false,
+    value: value
+  });
+}
+
+// Define Application interface, the getRequestedAppControl method will not be
+// implemented ATM.
+function Application(appInfo, contextId) {
+  defineReadOnlyProperty(this, 'appInfo', appInfo);
+  defineReadOnlyProperty(this, 'contextId', contextId);
+}
+
+Application.prototype.exit = function() {
+  var result = sendSyncMessage({ cmd: 'ExitCurrentApp' });
+  if (result.error != null)
+    throw new tizen.WebAPIException(tizen.WebAPIException.UNKNOWN_ERR);
 };
 
+Application.prototype.hide = function() {
+  var result = sendSyncMessage({ cmd: 'HideCurrentApp' });
+  if (result.error != null)
+    throw new tizen.WebAPIException(tizen.WebAPIException.UNKNOWN_ERR);
+};
+
+// ApplicationContext interface.
+function ApplicationContext(json) {
+  defineReadOnlyProperty(this, 'id', json.id);
+  defineReadOnlyProperty(this, 'appId', json.appId);
+}
+
+// ApplicationInformation interface.
 function ApplicationInformation(json) {
   for (var field in json) {
     var val = json[field];
     if (field === 'installDate')
       val = new Date(val * 1000);
-    Object.defineProperty(this, field, { writable: false, enumerable: true, value: val });
+    defineReadOnlyProperty(this, field, val);
   }
 }
 
@@ -45,13 +134,9 @@ exports.getAppInfo = function(appId) {
     throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
 
   var result = sendSyncMessage({ cmd: 'GetAppInfo', id: appId });
-  if (!result.error)
-    return new ApplicationInformation(result);
-
-  if (result.error === 'appinfo')
-    throw new tizen.WebAPIException(tizen.WebAPIException.NOT_FOUND_ERR);
-  else
-    throw new tizen.WebAPIException(tizen.WebAPIException.UNKNOWN_ERR);
+  if (result.error != null)
+    throw new tizen.WebAPIException(result.error);
+  return new ApplicationInformation(result.data);
 };
 
 exports.getAppsInfo = function(onsuccess, onerror) {
@@ -59,9 +144,12 @@ exports.getAppsInfo = function(onsuccess, onerror) {
       (onerror && typeof onerror !== 'function'))
     throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
 
-  var callbackId = setupCallback(function(result) {
-    if (result.error)
-      return onerror(new tizen.WebAPIError(tizen.WebAPIException.UNKNOWN_ERR));
+  var callbackId = asyncCallbacks.setup(function(result) {
+    if (result.error != null) {
+      if (!onerror)
+        return;
+      return onerror(new tizen.WebAPIError(result.error));
+    }
 
     var appsInfo = [];
     for (var i = 0, len = result.data.length; i < len; ++i)
@@ -71,4 +159,121 @@ exports.getAppsInfo = function(onsuccess, onerror) {
 
   var msg = { cmd: 'GetAppsInfo' };
   postMessage(msg, callbackId);
+};
+
+exports.getAppContext = function(contextId) {
+  if (contextId && !/^\d+$/.test(contextId))
+    throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
+
+  var result = sendSyncMessage({ cmd: 'GetAppContext', id: contextId});
+  if (result.error)
+    throw new tizen.WebAPIException(result.error);
+
+  return new ApplicationContext(result.data);
+};
+
+exports.getAppsContext = function(onsuccess, onerror) {
+  if ((typeof onsuccess !== 'function') ||
+      (onerror && typeof onerror !== 'function'))
+    throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
+
+  var callbackId = asyncCallbacks.setup(function(result) {
+    if (result.error != null) {
+      if (!onerror)
+        return;
+      return onerror(new tizen.WebAPIError(result.error));
+    }
+
+    var contexts = [];
+    for (var i = 0, len = result.data.length; i < len; ++i)
+      contexts.push(new ApplicationContext(result.data[i]));
+    return onsuccess(contexts);
+  });
+
+  var msg = { cmd: 'GetAppsContext' };
+  postMessage(msg, callbackId);
+};
+
+exports.getCurrentApplication = function() {
+  var result = sendSyncMessage({ cmd: 'GetCurrentApp' });
+  if (result.error)
+    throw new tizen.WebAPIException(result.error);
+
+  var appInfo = new ApplicationInformation(result.data.appInfo);
+  return new Application(appInfo, result.data.appContext.id);
+};
+
+exports.kill = function(contextId, onsuccess, onerror) {
+  if ((!/^\d+$/.test(contextId)) ||
+      (onsuccess && typeof onsuccess !== 'function') ||
+      (onerror && typeof onerror !== 'function'))
+    throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
+
+  var callbackId = asyncCallbacks.setup(function(result) {
+    if (result.error != null) {
+      if (!onerror)
+        return;
+      return onerror(new tizen.WebAPIError(result.code));
+    }
+    return onsuccess();
+  });
+
+  var msg = { cmd: 'KillApp', id: contextId };
+  postMessage(msg, callbackId);
+};
+
+exports.launch = function(appId, onsuccess, onerror) {
+  if ((typeof appId !== 'string') ||
+      (onsuccess && typeof onsuccess !== 'function') ||
+      (onerror && typeof onerror !== 'function'))
+    throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
+
+  var callbackId = asyncCallbacks.setup(function(result) {
+    if (result.error != null) {
+      if (!onerror)
+        return;
+      return onerror(new tizen.WebAPIError(result.error));
+    }
+    return onsuccess();
+  });
+
+  var msg = { cmd: 'LaunchApp', id: appId };
+  postMessage(msg, callbackId);
+};
+
+exports.addAppInfoEventListener = function(eventCallback) {
+  if (typeof eventCallback !== 'object' ||
+      typeof eventCallback.oninstalled !== 'function' ||
+      typeof eventCallback.onupdated !== 'function' ||
+      typeof eventCallback.onuninstalled !== 'function')
+    throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
+
+  var watchId = appInfoEventCallbacks.addCallback(function(result) {
+    if (result.installed) {
+      result.installed.forEach(function(appInfo) {
+        var appInfo = new ApplicationInformation(appInfo);
+        eventCallback.oninstalled(appInfo);
+      });
+    }
+    if (result.updated) {
+      result.updated.forEach(function(appInfo) {
+        var appInfo = new ApplicationInformation(appInfo);
+        eventCallback.onupdated(appInfo);
+      });
+    }
+    if (result.uninstalled) {
+      result.uninstalled.forEach(function(appId) {
+        eventCallback.onuninstalled(appId);
+      });
+    }
+  });
+
+  return watchId;
+};
+
+exports.removeAppInfoEventListener = function(watchId) {
+  if (typeof watchId !== 'number')
+    throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
+
+  appInfoEventCallbacks.removeCallback(watchId);
 };

--- a/application/application_context.cc
+++ b/application/application_context.cc
@@ -1,0 +1,103 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "application/application_context.h"
+
+#include <app_manager.h>
+#include <aul.h>
+#include <unistd.h>
+
+#include <memory>
+#include <utility>
+
+#include "application/application_extension_utils.h"
+
+namespace {
+
+bool GetAppContextCallback(app_context_h app_context, void* user_data) {
+  int pid;
+  picojson::array* data = static_cast<picojson::array*>(user_data);
+  if (app_context_get_pid(app_context, &pid) != APP_MANAGER_ERROR_NONE) {
+    std::cerr << "Fail to get pid from context.\n";
+    data->clear();
+    return false;
+  }
+
+  ApplicationContext app_ctx(std::to_string(pid));
+  if (!app_ctx.IsValid()) {
+    data->clear();
+    return false;
+  }
+
+  data->push_back(app_ctx.Value());
+  return true;
+}
+
+}  // namespace
+
+picojson::value* ApplicationContext::GetAllRunning() {
+  picojson::array contexts;
+  if (app_manager_foreach_app_context(GetAppContextCallback, &contexts)
+      != APP_MANAGER_ERROR_NONE) {
+    std::cerr << "Fail to call app_manager_foreach_app_context.\n";
+    return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
+  }
+
+  if (contexts.empty())
+    return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
+
+  return CreateResultMessage(contexts);
+}
+
+ApplicationContext::ApplicationContext(const std::string& context_id)
+    : error_(WebApiAPIErrors::NO_ERROR),
+      context_id_(context_id) {
+  int pid = std::stoi(context_id);
+  if (pid <= 0)
+    error_ = WebApiAPIErrors::NOT_FOUND_ERR;
+
+  char* app_id = NULL;
+  int ret = app_manager_get_app_id(pid, &app_id);
+  if (ret == APP_MANAGER_ERROR_NONE && app_id) {
+    app_id_ = app_id;
+    free(app_id);
+    return;
+  }
+
+  if (app_id)
+    free(app_id);
+  std::cerr << "Fail to get app id by pid: " << ret << std::endl;
+  switch (ret) {
+    case APP_MANAGER_ERROR_NO_SUCH_APP:
+    case APP_MANAGER_ERROR_INVALID_PARAMETER:
+      error_ = WebApiAPIErrors::NOT_FOUND_ERR;
+      break;
+    default:
+      error_ = WebApiAPIErrors::UNKNOWN_ERR;
+      break;
+  }
+}
+
+const picojson::value& ApplicationContext::Value() {
+  if (value_.is<picojson::null>() && IsValid()) {
+    picojson::object obj;
+    obj["id"] = picojson::value(context_id_);
+    obj["appId"] = picojson::value(app_id_);
+    value_ = picojson::value(obj);
+  }
+  return value_;
+}
+
+const std::string ApplicationContext::Serialize() {
+  std::unique_ptr<picojson::value> result;
+  if (!IsValid())
+    result.reset(CreateResultMessage(error_));
+  else
+    result.reset(CreateResultMessage(Value()));
+  return result->serialize();
+}
+
+bool ApplicationContext::IsValid() const {
+  return error_ == WebApiAPIErrors::NO_ERROR;
+}

--- a/application/application_context.h
+++ b/application/application_context.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef APPLICATION_APPLICATION_CONTEXT_H_
+#define APPLICATION_APPLICATION_CONTEXT_H_
+
+#include <memory>
+#include <string>
+
+#include "common/picojson.h"
+#include "tizen/tizen.h"
+
+class ApplicationContext {
+ public:
+  static picojson::value* GetAllRunning();
+
+  explicit ApplicationContext(const std::string& context_id);
+
+  const picojson::value& Value();
+  const std::string Serialize();
+  bool IsValid() const;
+
+ private:
+  WebApiAPIErrors error_;
+  std::string context_id_;
+  std::string app_id_;
+  picojson::value value_;
+};
+
+#endif  // APPLICATION_APPLICATION_CONTEXT_H_

--- a/application/application_extension.cc
+++ b/application/application_extension.cc
@@ -7,8 +7,9 @@
 #include <iostream>
 #include <sstream>
 
-#include "application/application_information.h"
+#include "application/application.h"
 #include "application/application_instance.h"
+#include "application/application_manager.h"
 #include "common/picojson.h"
 
 common::Extension* CreateExtension() {
@@ -31,23 +32,16 @@ common::Extension* CreateExtension() {
     return NULL;
   }
 
-  std::string app_id = ApplicationInformation::PkgIdToAppId(pkg_id);
-  if (app_id.empty()) {
-    std::cerr << "Can't translate app package ID to application ID."
-              << std::endl;
-    return NULL;
-  }
-
-  return new ApplicationExtension(app_id, pkg_id);
+  return new ApplicationExtension(pkg_id);
 }
 
 // This will be generated from application_api.js
 extern const char kSource_application_api[];
 
-ApplicationExtension::ApplicationExtension(const std::string& app_id,
-                                           const std::string& pkg_id)
-    : app_id_(app_id),
-      pkg_id_(pkg_id) {
+ApplicationExtension::ApplicationExtension(const std::string& pkg_id) {
+  current_app_.reset(new Application(pkg_id));
+  app_manager_.reset(new ApplicationManager());
+
   SetExtensionName("tizen.application");
   SetJavaScriptAPI(kSource_application_api);
 }

--- a/application/application_extension.h
+++ b/application/application_extension.h
@@ -5,25 +5,28 @@
 #ifndef APPLICATION_APPLICATION_EXTENSION_H_
 #define APPLICATION_APPLICATION_EXTENSION_H_
 
+#include <memory>
 #include <string>
 
 #include "common/extension.h"
 
+class Application;
+class ApplicationManager;
+
 class ApplicationExtension : public common::Extension {
  public:
-  ApplicationExtension(const std::string& app_id, const std::string& pkg_id);
+  explicit ApplicationExtension(const std::string& pkg_id);
   virtual ~ApplicationExtension();
 
-  const std::string& app_id() const { return app_id_; }
-
-  const std::string& pkg_id() const { return pkg_id_; }
+  Application* current_app() { return current_app_.get(); }
+  ApplicationManager* app_manager() { return app_manager_.get(); }
 
  private:
   // common::Extension implementation.
   virtual common::Instance* CreateInstance();
 
-  std::string app_id_;
-  std::string pkg_id_;
+  std::unique_ptr<Application> current_app_;
+  std::unique_ptr<ApplicationManager> app_manager_;
 };
 
 #endif  // APPLICATION_APPLICATION_EXTENSION_H_

--- a/application/application_extension_utils.h
+++ b/application/application_extension_utils.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef APPLICATION_APPLICATION_EXTENSION_UTILS_H_
+#define APPLICATION_APPLICATION_EXTENSION_UTILS_H_
+
+#include "common/picojson.h"
+#include "tizen/tizen.h"
+
+inline picojson::value* CreateResultMessage() {
+  return new picojson::value(picojson::object());
+}
+
+inline picojson::value* CreateResultMessage(WebApiAPIErrors error) {
+  picojson::object obj;
+  obj["error"] = picojson::value(static_cast<double>(error));
+  return new picojson::value(obj);
+}
+
+inline picojson::value* CreateResultMessage(const picojson::object& data) {
+  picojson::object obj;
+  obj["data"] = picojson::value(data);
+  return new picojson::value(obj);
+}
+
+inline picojson::value* CreateResultMessage(const picojson::array& data) {
+  picojson::object obj;
+  obj["data"] = picojson::value(data);
+  return new picojson::value(obj);
+}
+
+inline picojson::value* CreateResultMessage(const picojson::value& data) {
+  picojson::object obj;
+  obj["data"] = data;
+  return new picojson::value(obj);
+}
+
+#endif  // APPLICATION_APPLICATION_EXTENSION_UTILS_H_

--- a/application/application_information.h
+++ b/application/application_information.h
@@ -5,6 +5,7 @@
 #ifndef APPLICATION_APPLICATION_INFORMATION_H_
 #define APPLICATION_APPLICATION_INFORMATION_H_
 
+#include <memory>
 #include <string>
 
 #include "common/picojson.h"
@@ -25,13 +26,14 @@ class ApplicationInformation {
   explicit ApplicationInformation(const std::string& app_id);
   ~ApplicationInformation();
 
-  std::string Serialize() const;
-
- private:
+  const picojson::value& Value();
+  const std::string Serialize();
   bool IsValid() const;
 
-  picojson::value data_;
-  picojson::value error_;
+ private:
+  picojson::object data_;
+  picojson::object error_;
+  picojson::value value_;
 };
 
 #endif  // APPLICATION_APPLICATION_INFORMATION_H_

--- a/application/application_instance.cc
+++ b/application/application_instance.cc
@@ -4,17 +4,43 @@
 
 #include "application/application_instance.h"
 
+#include <memory>
+#include <iostream>
+#include <string>
+#include <sstream>
+
+#include "application/application.h"
+#include "application/application_context.h"
 #include "application/application_extension.h"
 #include "application/application_information.h"
+#include "application/application_manager.h"
 
-#include <memory>
-#include <string>
+namespace {
+
+const char kJSCallbackKey[] = "_callback";
+const char kAppInfoEventCallback[] = "_appInfoEventCallback";
+
+double GetJSCallbackId(const picojson::value& msg) {
+  assert(msg.contains(kJSCallbackKey));
+  const picojson::value& id_value = msg.get(kJSCallbackKey);
+  return id_value.get<double>();
+}
+
+void SetJSCallbackId(picojson::value& msg, double id) {
+  assert(msg.is<picojson::object>());
+  msg.get<picojson::object>()[kJSCallbackKey] = picojson::value(id);
+}
+
+}  // namespace
 
 ApplicationInstance::ApplicationInstance(ApplicationExtension* extension)
     : extension_(extension) {
 }
 
 ApplicationInstance::~ApplicationInstance() {
+  ApplicationManager* manager = extension_->app_manager();
+  if (manager->IsInstanceRegistered(this))
+    manager->UnregisterAppInfoEvent(this);
 }
 
 void ApplicationInstance::HandleMessage(const char* msg) {
@@ -30,6 +56,12 @@ void ApplicationInstance::HandleMessage(const char* msg) {
   std::string cmd = v.get("cmd").to_str();
   if (cmd == "GetAppsInfo") {
     HandleGetAppsInfo(v);
+  } else if (cmd == "GetAppsContext") {
+    HandleGetAppsContext(v);
+  } else if (cmd == "KillApp") {
+    HandleKillApp(v);
+  } else if (cmd == "LaunchApp") {
+    HandleLaunchApp(v);
   } else {
     std::cout << "ASSERT NOT REACHED.\n";
   }
@@ -48,31 +80,105 @@ void ApplicationInstance::HandleSyncMessage(const char* msg) {
   std::string cmd = v.get("cmd").to_str();
   if (cmd == "GetAppInfo") {
     HandleGetAppInfo(v);
+  } else if (cmd == "GetAppContext") {
+    HandleGetAppContext(v);
+  } else if (cmd == "GetCurrentApp") {
+    HandleGetCurrentApp();
+  } else if (cmd == "ExitCurrentApp") {
+    HandleExitCurrentApp();
+  } else if (cmd == "HideCurrentApp") {
+    HandleHideCurrentApp();
+  } else if (cmd == "RegisterAppInfoEvent") {
+    HandleRegisterAppInfoEvent();
+  } else if (cmd == "UnregisterAppInfoEvent") {
+    HandleUnregisterAppInfoEvent();
   } else {
     std::cout << "ASSERT NOT REACHED.\n";
   }
 }
 
-void ApplicationInstance::HandleGetAppInfo(picojson::value& msg) {
-  std::string app_id;
-  if (msg.contains("id") && msg.get("id").is<std::string>())
-    app_id = msg.get("id").to_str();
-  else
-    app_id = extension_->app_id();
-
-  ApplicationInformation app_info(app_id);
-  SendSyncReply(app_info.Serialize().c_str());
+void ApplicationInstance::HandleGetAppInfo(const picojson::value& msg) {
+  if (msg.contains("id") && msg.get("id").is<std::string>()) {
+    ApplicationInformation app_info(msg.get("id").to_str());
+    SendSyncReply(app_info.Serialize().c_str());
+  } else {
+    Application* current_app = extension_->current_app();
+    SendSyncReply(current_app->GetAppInfo().Serialize().c_str());
+  }
 }
 
-void ApplicationInstance::HandleGetAppsInfo(picojson::value& msg) {
+void ApplicationInstance::HandleGetAppContext(const picojson::value& msg) {
+  if (msg.contains("id") && msg.get("id").is<std::string>()) {
+    ApplicationContext app_ctx(msg.get("id").to_str());
+    SendSyncReply(app_ctx.Serialize().c_str());
+  } else {
+    Application* current_app = extension_->current_app();
+    SendSyncReply(current_app->GetAppContext().Serialize().c_str());
+  }
+}
+
+void ApplicationInstance::HandleGetCurrentApp() {
+  SendSyncReply(extension_->current_app()->Serialize().c_str());
+}
+
+void ApplicationInstance::HandleExitCurrentApp() {
+  std::unique_ptr<picojson::value> result(
+      extension_->current_app()->Exit());
+  SendSyncReply(result->serialize().c_str());
+}
+
+void ApplicationInstance::HandleHideCurrentApp() {
+  std::unique_ptr<picojson::value> result(
+      extension_->current_app()->Hide());
+  SendSyncReply(result->serialize().c_str());
+}
+
+void ApplicationInstance::HandleRegisterAppInfoEvent() {
+  auto post_event = std::bind(&ApplicationInstance::PostAppInfoEventMessage,
+      this, std::placeholders::_1);
+  std::unique_ptr<picojson::value> result(
+      extension_->app_manager()->RegisterAppInfoEvent(this, post_event));
+  SendSyncReply(result->serialize().c_str());
+}
+
+void ApplicationInstance::HandleUnregisterAppInfoEvent() {
+  std::unique_ptr<picojson::value> result(
+      extension_->app_manager()->UnregisterAppInfoEvent(this));
+  SendSyncReply(result->serialize().c_str());
+}
+
+void ApplicationInstance::HandleGetAppsInfo(const picojson::value& msg) {
   std::unique_ptr<picojson::value> result(
       ApplicationInformation::GetAllInstalled());
-  ReturnMessageAsync(msg, result->get<picojson::object>());
+  ReturnMessageAsync(GetJSCallbackId(msg), *result);
 }
 
-void ApplicationInstance::ReturnMessageAsync(picojson::value& msg,
-                                             const picojson::object& obj) {
-  picojson::object& msg_obj = msg.get<picojson::object>();
-  msg_obj.insert(obj.begin(), obj.end());
-  PostMessage(msg.serialize().c_str());
+void ApplicationInstance::HandleGetAppsContext(const picojson::value& msg) {
+  std::unique_ptr<picojson::value> result(ApplicationContext::GetAllRunning());
+  ReturnMessageAsync(GetJSCallbackId(msg), *result);
+}
+
+void ApplicationInstance::HandleKillApp(const picojson::value& msg) {
+  std::string context_id = msg.get("id").to_str();
+  std::unique_ptr<picojson::value> result(
+      extension_->app_manager()->KillApp(context_id));
+  ReturnMessageAsync(GetJSCallbackId(msg), *result);
+}
+
+void ApplicationInstance::HandleLaunchApp(const picojson::value& msg) {
+  std::string app_id = msg.get("id").to_str();
+  std::unique_ptr<picojson::value> result(
+      extension_->app_manager()->LaunchApp(app_id));
+  ReturnMessageAsync(GetJSCallbackId(msg), *result);
+}
+
+void ApplicationInstance::ReturnMessageAsync(double callback_id,
+                                             picojson::value& value) {
+  SetJSCallbackId(value, callback_id);
+  PostMessage(value.serialize().c_str());
+}
+
+void ApplicationInstance::PostAppInfoEventMessage(picojson::object& events) {
+  events[kJSCallbackKey] = picojson::value(kAppInfoEventCallback);
+  PostMessage(picojson::value(events).serialize().c_str());
 }

--- a/application/application_instance.h
+++ b/application/application_instance.h
@@ -5,6 +5,8 @@
 #ifndef APPLICATION_APPLICATION_INSTANCE_H_
 #define APPLICATION_APPLICATION_INSTANCE_H_
 
+#include <functional>
+
 #include "common/extension.h"
 #include "common/picojson.h"
 
@@ -20,10 +22,23 @@ class ApplicationInstance : public common::Instance {
   virtual void HandleMessage(const char* msg);
   virtual void HandleSyncMessage(const char* msg);
 
-  void HandleGetAppInfo(picojson::value& msg);
-  void HandleGetAppsInfo(picojson::value& msg);
+  // Synchronous message handlers.
+  void HandleGetAppInfo(const picojson::value& msg);
+  void HandleGetAppContext(const picojson::value& msg);
+  void HandleGetCurrentApp();
+  void HandleExitCurrentApp();
+  void HandleHideCurrentApp();
+  void HandleRegisterAppInfoEvent();
+  void HandleUnregisterAppInfoEvent();
 
-  void ReturnMessageAsync(picojson::value& msg, const picojson::object& obj);
+  // Asynchronous message handlers.
+  void HandleGetAppsInfo(const picojson::value& msg);
+  void HandleGetAppsContext(const picojson::value& msg);
+  void HandleKillApp(const picojson::value& msg);
+  void HandleLaunchApp(const picojson::value& msg);
+
+  void ReturnMessageAsync(double callback_id, picojson::value& value);
+  void PostAppInfoEventMessage(picojson::object& events);
 
   ApplicationExtension* extension_;
 };

--- a/application/application_manager.cc
+++ b/application/application_manager.cc
@@ -1,0 +1,247 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "application/application_manager.h"
+
+#include <app_manager.h>
+#include <aul.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <iostream>
+
+#include "application/application_extension_utils.h"
+#include "application/application_information.h"
+#include "application/application_instance.h"
+#include "tizen/tizen.h"
+
+namespace {
+
+// Application information events.
+const char kOkayEvent[] = "ok";
+const char kInstallEvent[] = "install";
+const char kUpdateEvent[] = "update";
+const char kUninstallEvent[] = "uninstall";
+const char kEventStart[] = "start";
+const char kEventEnd[] = "end";
+
+bool PackageToAppCallback(package_info_app_component_type_e comp_type,
+                          const char* app_id, void* user_data) {
+  if (app_id == NULL) {
+    std::cerr << "No app id passed in the pakage to app callback.\n";
+    return true;
+  }
+
+  std::vector<std::string>* app_ids =
+      static_cast<std::vector<std::string>*>(user_data);
+  app_ids->push_back(app_id);
+  return true;
+}
+
+void RetrievePackageAppIds(const char* package,
+                           std::vector<std::string>& app_ids) {
+  package_info_h package_info;
+  if (package_manager_get_package_info(package, &package_info)
+      != PACKAGE_MANAGER_ERROR_NONE) {
+    std::cerr << "Cannot create package info.\n";
+    return;
+  }
+
+  if (package_info_foreach_app_from_package(
+        package_info, PACKAGE_INFO_ALLAPP, PackageToAppCallback, &app_ids)
+      != PACKAGE_MANAGER_ERROR_NONE) {
+    std::cerr << "Failed while getting appids.\n";
+    return;
+  }
+
+  if (package_info_destroy(package_info) != PACKAGE_MANAGER_ERROR_NONE)
+    std::cerr << "Cannot destroy package info.\n";
+}
+
+int AppEventsCallback(int id, const char* type, const char* package,
+                      const char* key, const char* val,
+                      const void* msg, void* data) {
+  std::string event_type(val);
+  std::string event_state(key);
+  std::transform(
+      event_type.begin(), event_type.end(), event_type.begin(), ::tolower);
+  std::transform(
+      event_state.begin(), event_state.end(), event_state.begin(), ::tolower);
+
+  ApplicationManager* manager = static_cast<ApplicationManager*>(data);
+  std::vector<std::string> app_ids;
+  if ((event_type == kUninstallEvent && event_state == kEventStart) ||
+      (event_type != kUninstallEvent && event_state == kEventEnd))
+    RetrievePackageAppIds(package, app_ids);
+  manager->OnAppInfoEvent(event_type, event_state, app_ids);
+
+  return APP_MANAGER_ERROR_NONE;
+}
+
+}  // namespace
+
+ApplicationManager::ApplicationManager()
+    : pkgmgr_handle_(NULL) {
+}
+
+ApplicationManager::~ApplicationManager() {
+  if (pkgmgr_handle_)
+    pkgmgr_client_free(pkgmgr_handle_);
+}
+
+// FIXME(xiang): Using PID as app context ID may introduce a corner case bug.
+// See details at: https://crosswalk-project.org/jira/browse/XWALK-1563.
+picojson::value* ApplicationManager::KillApp(const std::string& context_id) {
+  pid_t pid = std::stoi(context_id);
+  if (pid == getpid())
+    return CreateResultMessage(WebApiAPIErrors::INVALID_VALUES_ERR);
+
+  char* app_id = NULL;
+  app_context_h app_context = NULL;
+  WebApiAPIErrors error = WebApiAPIErrors::NO_ERROR;
+
+  int ret = app_manager_get_app_id(pid, &app_id);
+  if (ret != APP_MANAGER_ERROR_NONE) {
+    std::cerr << "Fail to get app id by pid: " << ret << std::endl;
+    switch (ret) {
+      case APP_MANAGER_ERROR_NO_SUCH_APP:
+      case APP_MANAGER_ERROR_INVALID_PARAMETER:
+        error = WebApiAPIErrors::NOT_FOUND_ERR;
+        break;
+      default:
+        error = WebApiAPIErrors::UNKNOWN_ERR;
+    }
+    goto end;
+  }
+
+  ret = app_manager_get_app_context(app_id, &app_context);
+  if (ret != APP_MANAGER_ERROR_NONE) {
+    std::cerr << "Fail to get app_context: " << ret << std::endl;
+    error = WebApiAPIErrors::NOT_FOUND_ERR;
+    goto end;
+  }
+
+  ret = app_manager_terminate_app(app_context);
+  if (ret != APP_MANAGER_ERROR_NONE) {
+    std::cerr << "Fail to termniate app: " << ret << std::endl;
+    error = WebApiAPIErrors::UNKNOWN_ERR;
+    goto end;
+  }
+
+ end:
+  if (app_id)
+    free(app_id);
+  if (app_context)
+    app_context_destroy(app_context);
+  return error == WebApiAPIErrors::NO_ERROR ?
+      CreateResultMessage() : CreateResultMessage(error);
+}
+
+picojson::value* ApplicationManager::LaunchApp(const std::string& app_id) {
+  WebApiAPIErrors error = WebApiAPIErrors::NO_ERROR;
+  int ret = aul_open_app(app_id.c_str());
+  if (ret < 0) {
+    switch (ret) {
+      case AUL_R_EINVAL:
+      case AUL_R_ERROR:
+        return CreateResultMessage(WebApiAPIErrors::NOT_FOUND_ERR);
+      default:
+        return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
+    }
+  }
+
+  return CreateResultMessage();
+}
+
+picojson::value* ApplicationManager::RegisterAppInfoEvent(
+      ApplicationInstance* instance,
+      const AppInfoEventCallback& event_callback) {
+  if (instances_.empty()) {
+    assert(!pkgmgr_handle_);
+    pkgmgr_handle_ = pkgmgr_client_new(PC_LISTENING);
+    if (!pkgmgr_handle_)
+      return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
+    else
+      pkgmgr_client_listen_status(pkgmgr_handle_, AppEventsCallback, this);
+  }
+
+  if (IsInstanceRegistered(instance)) {
+    std::cerr << "Instance already registered app info events.\n";
+    return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
+  }
+
+  instances_.insert(std::make_pair(instance, event_callback));
+  return CreateResultMessage();
+}
+
+picojson::value* ApplicationManager::UnregisterAppInfoEvent(
+    ApplicationInstance* instance) {
+  auto iter = instances_.find(instance);
+  if (iter == instances_.end()) {
+    std::cerr << "Instance not registered app info events.\n";
+    return CreateResultMessage(WebApiAPIErrors::NOT_FOUND_ERR);
+  }
+
+  instances_.erase(iter);
+  if (instances_.empty()) {
+    assert(pkgmgr_handle_);
+    pkgmgr_client_free(pkgmgr_handle_);
+    pkgmgr_handle_ = NULL;
+  }
+
+  return CreateResultMessage();
+}
+
+bool ApplicationManager::IsInstanceRegistered(
+    ApplicationInstance* const instance) const {
+  return instances_.find(instance) != instances_.end();
+}
+
+void ApplicationManager::OnAppInfoEvent(
+    const std::string& event_type,
+    const std::string& event_state,
+    const std::vector<std::string>& app_ids) {
+  // Previously started event is finished, then we can send corresponding info
+  // to registered instances.
+  if (!started_event_.empty() && event_state == kEventEnd &&
+      event_type == kOkayEvent) {
+    picojson::array data;
+    picojson::object result;
+
+    if (started_event_ == kInstallEvent || started_event_ == kUpdateEvent) {
+      for (auto it = app_ids.begin(); it != app_ids.end(); ++it) {
+        ApplicationInformation app_info(*it);
+        if (app_info.IsValid())
+          data.push_back(app_info.Value());
+      }
+      if (started_event_ == kInstallEvent)
+        result["installed"] = picojson::value(data);
+      else
+        result["updated"] = picojson::value(data);
+    }
+
+    if (started_event_ == kUninstallEvent) {
+      auto it = uninstalled_app_ids_.begin();
+      for (; it != uninstalled_app_ids_.end(); ++it)
+        data.push_back(picojson::value(*it));
+      result["uninstalled"] = picojson::value(data);
+      uninstalled_app_ids_.clear();
+    }
+
+    started_event_.clear();
+    auto instance_it = instances_.begin();
+    for (; instance_it != instances_.end(); ++instance_it)
+      instance_it->second(result);
+  }
+
+  // Save just one event as the events will not notified interleaved.
+  if (event_state == kEventStart) {
+    if (!started_event_.empty())
+      std::cerr << "Event received before previous event finished.\n";
+    started_event_ = event_type;
+    // After uninstallation we cannot get app ids from package name.
+    if (event_type == kUninstallEvent)
+      uninstalled_app_ids_ = app_ids;
+  }
+}

--- a/application/application_manager.h
+++ b/application/application_manager.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef APPLICATION_APPLICATION_MANAGER_H_
+#define APPLICATION_APPLICATION_MANAGER_H_
+
+#include <package_manager.h>
+#include <package-manager.h>
+
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "common/picojson.h"
+
+class ApplicationInstance;
+
+class ApplicationManager {
+ public:
+  ApplicationManager();
+  ~ApplicationManager();
+
+  picojson::value* KillApp(const std::string& context_id);
+  picojson::value* LaunchApp(const std::string& app_id);
+
+  // Application information events registration/unregistration handlers.
+  typedef std::function<void(picojson::object&)> AppInfoEventCallback;
+  picojson::value* RegisterAppInfoEvent(
+      ApplicationInstance* instance,
+      const AppInfoEventCallback& event_callback);
+  picojson::value* UnregisterAppInfoEvent(ApplicationInstance* instance);
+  bool IsInstanceRegistered(ApplicationInstance* const instance) const;
+
+  void OnAppInfoEvent(const std::string& event_type,
+                      const std::string& event_state,
+                      const std::vector<std::string>& app_ids);
+
+ private:
+  pkgmgr_client* pkgmgr_handle_;
+  std::string started_event_;
+  std::vector<std::string> uninstalled_app_ids_;
+
+  typedef std::map<ApplicationInstance*, AppInfoEventCallback>
+      AppInfoEventInstanceMap;
+  AppInfoEventInstanceMap instances_;
+};
+
+#endif  // APPLICATION_APPLICATION_MANAGER_H_


### PR DESCRIPTION
The supported APIs are listed below:
Application,
ApplicationContext,
ApplicationManager.getCurrentApplication,
ApplicationManager.getAppContext/getAppsContext,
ApplicationManager.kill/launch,
ApplicationManager.addAppInfoEventListener/removeAppInfoEventListener

As we runs extension process logic on launcher now, the AUL related APIs can be
directly called in this extension.
The C++ Application class will represent current running application and owned
by ApplicationExtension. The ApplicationManager class will provide methods to
manipulate other applications and listening to package events.
