### PR TITLE
[Tizen] Fix for File.length and File.fileSize properties

### DIFF
--- a/filesystem/filesystem_api.js
+++ b/filesystem/filesystem_api.js
@@ -424,14 +424,17 @@ function File(fullPath, parent) {
     if (status.isError)
       return 0;
     if (status.isDirectory)
-      return 0;
+      return undefined;
     return status.size;
   };
   var getLength = function() {
-    if (getIsFile())
-      return 1;
-    return files.length;
-  };
+    var status = stat();
+    if (status.isError)
+      return 0;
+    if (status.isDirectory)
+      return status.length;
+    return undefined;
+   };
 
   Object.defineProperties(this, {
     'parent': { get: getParent, enumerable: true },


### PR DESCRIPTION
File.length should be undefined for files and defined for directories,
while fileSize should be only available for regular files.
