### PR TITLE
[Tizen] Move MediaServer dbus objects to worker thread

### DIFF
--- a/mediaserver/mediaserver_extension.cc
+++ b/mediaserver/mediaserver_extension.cc
@@ -8,7 +8,6 @@
 #include "mediaserver/mediaserver_instance.h"
 
 common::Extension* CreateExtension() {
-  g_type_init();
   return new MediaServerExtension;
 }
 

--- a/mediaserver/mediaserver_instance.cc
+++ b/mediaserver/mediaserver_instance.cc
@@ -9,12 +9,41 @@
 #include "common/picojson.h"
 #include "mediaserver/mediaserver_manager.h"
 
-MediaServerInstance::MediaServerInstance() {
-  media_server_manager_ = new MediaServerManager(this);
+MediaServerInstance::MediaServerInstance()
+    : worker_thread_(&MediaServerInstance::InitWorkerThread, this) {
+  worker_thread_.detach();
 }
 
 MediaServerInstance::~MediaServerInstance() {
+  g_main_loop_quit(worker_loop_);
   delete media_server_manager_;
+}
+
+gboolean MediaServerInstance::CreateMediaServerManager(void* data) {
+  if (!data) {
+    std::cerr << "Null pointer is passed to callback" << std::endl;
+    return FALSE;
+  }
+
+  MediaServerInstance* instance = static_cast<MediaServerInstance*>(data);
+  instance->media_server_manager_ = new MediaServerManager(instance);
+  return FALSE;
+}
+
+void MediaServerInstance::InitWorkerThread() {
+  GMainContext* context = g_main_context_default();
+  worker_loop_ = g_main_loop_new(context, FALSE);
+  g_main_context_push_thread_default(context);
+  GSource* source = g_idle_source_new();
+  g_source_set_callback(source,
+                        &MediaServerInstance::CreateMediaServerManager,
+                        this,
+                        NULL);
+  g_source_attach(source, context);
+  g_main_loop_run(worker_loop_);
+  g_source_destroy(source);
+  g_source_unref(source);
+  g_main_loop_unref(worker_loop_);
 }
 
 void MediaServerInstance::HandleMessage(const char* message) {

--- a/mediaserver/mediaserver_instance.h
+++ b/mediaserver/mediaserver_instance.h
@@ -5,6 +5,8 @@
 #ifndef MEDIASERVER_MEDIASERVER_INSTANCE_H_
 #define MEDIASERVER_MEDIASERVER_INSTANCE_H_
 
+#include <glib.h>
+#include <thread>
 #include "common/extension.h"
 
 class MediaServerManager;
@@ -19,12 +21,16 @@ class MediaServerInstance : public common::Instance {
   virtual ~MediaServerInstance();
 
  private:
+  void InitWorkerThread();
+  static gboolean CreateMediaServerManager(void* data);
   // common::Instance implementation.
   virtual void HandleMessage(const char* msg);
   virtual void HandleSyncMessage(const char* msg);
 
  private:
-  MediaServerManager* media_server_manager_;
+  std::thread worker_thread_;
+  GMainLoop* worker_loop_ = NULL;
+  MediaServerManager* media_server_manager_ = NULL;
 };
 
 #endif  // MEDIASERVER_MEDIASERVER_INSTANCE_H_


### PR DESCRIPTION
This patch adds new worker thread with g_main_loop for async
dbus call processing.
