### PR TITLE
[Content] Update instance counter in anycase

### DIFF
--- a/content/content_instance.cc
+++ b/content/content_instance.cc
@@ -27,11 +27,11 @@ std::string pathToURI(const std::string path) {
 unsigned ContentInstance::m_instanceCount = 0;
 
 ContentInstance::ContentInstance() {
+  ++m_instanceCount;
   if (media_content_connect() != MEDIA_CONTENT_ERROR_NONE) {
-    std::cerr << "media_content_connect: error\n";
+    std::cerr << "media_content_connect: DB connection error" << std::endl;
     return;
   }
-  ++m_instanceCount;
 }
 
 ContentInstance::~ContentInstance() {


### PR DESCRIPTION
Update the instance counter in any case and not just when connected sucesfully
to the database. Otherwise, the assert will cause crash in dtor later on.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1599
