### PR TITLE
[Application] Add application metadata support

### DIFF
--- a/application/application.cc
+++ b/application/application.cc
@@ -58,6 +58,13 @@ Application::~Application() {
     g_object_unref(running_app_proxy_);
 }
 
+
+const std::string Application::GetAppId() {
+  if (app_id_.empty() && !RetrieveAppId())
+    return "";
+  return app_id_;
+}
+
 ApplicationInformation Application::GetAppInfo() {
   if (app_id_.empty() && !RetrieveAppId())
     // Return an invalid ApplicationInformation by passing an empty app ID.

--- a/application/application.h
+++ b/application/application.h
@@ -20,6 +20,7 @@ class Application {
   explicit Application(const std::string& pkg_id);
   ~Application();
 
+  const std::string GetAppId();
   ApplicationInformation GetAppInfo();
   ApplicationContext GetAppContext();
 

--- a/application/application_api.js
+++ b/application/application_api.js
@@ -129,6 +129,12 @@ function ApplicationInformation(json) {
   }
 }
 
+// ApplicationMetaData interface.
+function ApplicationMetaData(json) {
+  defineReadOnlyProperty(this, 'key', json.key);
+  defineReadOnlyProperty(this, 'value', json.value);
+}
+
 exports.getAppInfo = function(appId) {
   if (typeof appId !== 'string' && appId != undefined)
     throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
@@ -276,4 +282,18 @@ exports.removeAppInfoEventListener = function(watchId) {
     throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
 
   appInfoEventCallbacks.removeCallback(watchId);
+};
+
+exports.getAppMetaData = function(appId) {
+  if (typeof appId !== 'string' && appId != undefined)
+    throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
+
+  var result = sendSyncMessage({ cmd: 'GetAppMetaData', id: appId });
+  if (result.error != null)
+    throw new tizen.WebAPIException(result.error);
+
+  var data = [];
+  for (var i = 0, len = result.data.length; i < len; ++i)
+      data.push(new ApplicationMetaData(result.data[i]));
+  return data;
 };

--- a/application/application_instance.cc
+++ b/application/application_instance.cc
@@ -92,6 +92,8 @@ void ApplicationInstance::HandleSyncMessage(const char* msg) {
     HandleRegisterAppInfoEvent();
   } else if (cmd == "UnregisterAppInfoEvent") {
     HandleUnregisterAppInfoEvent();
+  } else if (cmd == "GetAppMetaData") {
+    HandleGetAppMetaData(v);
   } else {
     std::cout << "ASSERT NOT REACHED.\n";
   }
@@ -144,6 +146,19 @@ void ApplicationInstance::HandleRegisterAppInfoEvent() {
 void ApplicationInstance::HandleUnregisterAppInfoEvent() {
   std::unique_ptr<picojson::value> result(
       extension_->app_manager()->UnregisterAppInfoEvent(this));
+  SendSyncReply(result->serialize().c_str());
+}
+
+void ApplicationInstance::HandleGetAppMetaData(const picojson::value& msg) {
+  std::string app_id;
+  if (msg.contains("id") && msg.get("id").is<std::string>()) {
+    app_id = msg.get("id").to_str();
+  } else {
+    app_id = extension_->current_app()->GetAppId();
+  }
+
+  std::unique_ptr<picojson::value> result(
+      extension_->app_manager()->GetAppMetaData(app_id));
   SendSyncReply(result->serialize().c_str());
 }
 

--- a/application/application_instance.h
+++ b/application/application_instance.h
@@ -30,6 +30,7 @@ class ApplicationInstance : public common::Instance {
   void HandleHideCurrentApp();
   void HandleRegisterAppInfoEvent();
   void HandleUnregisterAppInfoEvent();
+  void HandleGetAppMetaData(const picojson::value& msg);
 
   // Asynchronous message handlers.
   void HandleGetAppsInfo(const picojson::value& msg);

--- a/application/application_manager.h
+++ b/application/application_manager.h
@@ -24,6 +24,7 @@ class ApplicationManager {
 
   picojson::value* KillApp(const std::string& context_id);
   picojson::value* LaunchApp(const std::string& app_id);
+  picojson::value* GetAppMetaData(const std::string& app_id);
 
   // Application information events registration/unregistration handlers.
   typedef std::function<void(picojson::object&)> AppInfoEventCallback;

--- a/examples/application.html
+++ b/examples/application.html
@@ -67,6 +67,16 @@ Input kill app context: <input type="text" id="kill_context_id" value=""></input
 <br>
 <input type="button" value="HideCurrentApp" onclick="handleHideApp()"></input>
 
+
+<br>
+<br>
+Input app ID: <input type="text" id="meta_app_id" value="current app ID"></input>
+<input type="button" value="GetAppMetaData" onclick="handleGetAppMetaData()"></input>
+<br>
+<br>Application meta data:</br>
+<textarea id="app_meta_data" rows="4" cols="64"></textarea>
+
+
 <pre id="console"></pre>
 <script src="js/js-test-pre.js"></script>
 <script>
@@ -232,6 +242,25 @@ function handleExitApp() {
 function handleHideApp() {
   try {
     tizen.application.getCurrentApplication().hide();
+  } catch (err) {
+    debug(err.name);
+  }
+}
+
+function handleGetAppMetaData() {
+  try {
+    var app_id = document.getElementById("meta_app_id");
+    var data;
+    if (app_id.value === "current app ID")
+      data = tizen.application.getAppMetaData();
+    else
+      data = tizen.application.getAppMetaData(app_id.value);
+
+    var output = document.getElementById("app_meta_data");
+    for (var i = 0; i < data.length; ++i) {
+      output.value += "key: " + data.key + "\n";
+      output.value += "value: " + data.value + "\n";
+    }
   } catch (err) {
     debug(err.name);
   }


### PR DESCRIPTION
Below APIs are added:
ApplicationMetaData
ApplicationManager.getAppMetaData

Application metadata is specified in config.xml and can be readonly accessed by
both native and web applications.

BUG=XWALK-1610
