### PR TITLE
[Content] TCT crash and passrate fixes

### DIFF
--- a/content/content_api.js
+++ b/content/content_api.js
@@ -183,6 +183,17 @@ ContentManager.prototype.find = function(onsuccess, onerror, directoryId, filter
 }
 
 ContentManager.prototype.scanFile = function(contentURI, onsuccess, onerror) {
+  postMessage({
+      cmd: 'ContentManager.scanFile',
+      contentURI: contentURI
+    }, function(result) {
+      if (result.isError) {
+        if (onerror)
+          onerror(new tizen.WebAPIError(result.errorCode));
+      } else if (onsuccess) {
+        onsuccess(contentURI);
+      }
+  });
 }
 
 ContentManager.prototype.setChangeListener = function(onchange) {

--- a/content/content_instance.h
+++ b/content/content_instance.h
@@ -37,6 +37,8 @@ class ContentInstance : public common::Instance {
     ContentFolderList *);
   void HandleFindRequest(const picojson::value& json);
   void HandleFindReply(const picojson::value& json, ContentItemList *);
+  void HandleScanFileRequest(const picojson::value& json);
+  void HandleScanFileReply(const picojson::value& json);
 
   // Asynchronous message helpers
   void PostAsyncErrorReply(const picojson::value&, WebApiAPIErrors);
@@ -69,7 +71,7 @@ class ContentFolder {
   void setModifiedDate(const std::string& modifiedDate) {
     modifiedDate_ = modifiedDate; }
 
-#ifdef DEBUG
+#ifdef DEBUG_ITEM
   void print(void);
 #endif
 
@@ -145,7 +147,7 @@ class ContentItem {
   double longitude() const { return latitude_; }
   void setLongitude(double latitude) { latitude_ = latitude; }
 
-#ifdef DEBUG
+#ifdef DEBUG_ITEM
   void print(void);
 #endif
 

--- a/examples/content.html
+++ b/examples/content.html
@@ -98,7 +98,13 @@ function handleScanFile()
 {
   try {
     debug('tizen.content.scanFile:');
-    tizen.content.scanFile();
+    tizen.content.scanFile("file:///opt/usr/media/Images/Default.jpg",
+      function(uri) {
+        debug("scan OK: " + uri);
+      },
+      function(err) {
+        debug("scan ERR: ")
+      });
   }
   catch (err) {
     debug(err.name);


### PR DESCRIPTION
Implement scanFile method which is heavily used by the TCT web api test suite.

Fix a crash for filter with invalid parameters (no bug yet).
