### PR TITLE
SysInfoDisplayWayland: Make Display adhere to our coding style.

### DIFF
--- a/system_info/system_info_display_wayland.cc
+++ b/system_info/system_info_display_wayland.cc
@@ -20,16 +20,16 @@
 #endif
 
 class Display {
-  public:
-    Display();
+ public:
+  Display();
 
-    wl_display* display;
-    wl_registry* registry;
-    wl_output* output;
-    int width;
-    int height;
-    double physical_width;
-    double physical_height;
+  wl_display* display;
+  wl_registry* registry;
+  wl_output* output;
+  int width;
+  int height;
+  double physical_width;
+  double physical_height;
 };
 
 Display::Display()


### PR DESCRIPTION
cpplint.py was recently updated in depot_tools, and introduces a newer style
check for the indentation of items in a class declaration.
