### PR TITLE
[Tizen] Add runtime deps needed by the Content API

### DIFF
--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -64,6 +64,9 @@ BuildRequires: pkgconfig(xrandr)
 %endif
 BuildRequires: python
 Requires:      crosswalk
+# For Content API
+Requires:      media-data-sdk
+Requires:      media-thumbnail-server
 
 %description
 Tizen Web APIs implemented using Crosswalk.


### PR DESCRIPTION
In order to run Content API properly, the following packages needs to be installed
- media-data-sdk - creates the media database (/opt/usr/dbspace/.media.db)
- media-tumbnail-server - service to create tumbnails. Pulls is also media-server.
