### PR TITLE
[Tizen] Remove media-data-sdk dependency

### DIFF
--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -65,7 +65,6 @@ BuildRequires: pkgconfig(xrandr)
 BuildRequires: python
 Requires:      crosswalk
 # For Content API
-Requires:      media-data-sdk
 Requires:      media-thumbnail-server
 
 %description


### PR DESCRIPTION
Since https://review.tizen.org/gerrit/16493/ is now merged,
the media-data-sdk is not needed anymore. The .media.db is nwo created
by the media-server package which is pulled in my the media-thumbnail-server.
