### PR TITLE
Correct --external-extensions-path for 64-bit

### DIFF
--- a/packaging/tizen-extensions-crosswalk
+++ b/packaging/tizen-extensions-crosswalk
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-if [ ! -f /usr/bin/xwalk ]; then
-   echo "The xwalk binary could not be found. Exiting."
-   exit 1
-fi
-
-exec /usr/bin/xwalk --allow-external-extensions-for-remote-sources --external-extensions-path=/usr/lib/tizen-extensions-crosswalk "$@"

--- a/packaging/tizen-extensions-crosswalk.in
+++ b/packaging/tizen-extensions-crosswalk.in
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ ! -f /usr/bin/xwalk ]; then
+   echo "The xwalk binary could not be found. Exiting."
+   exit 1
+fi
+
+exec /usr/bin/xwalk --allow-external-extensions-for-remote-sources --external-extensions-path=@LIB_INSTALL_DIR@/tizen-extensions-crosswalk "$@"

--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -14,7 +14,7 @@ Group:      Development/Libraries
 Summary:    Tizen Web APIs implemented using Crosswalk
 URL:        https://github.com/otcshare/tizen-extensions-crosswalk
 Source0:    %{name}-%{version}.tar.gz
-Source1:    %{name}
+Source1:    %{name}.in
 Source2:    %{name}.png
 Source3:    %{_bluetooth_demo_package}
 Source4:    %{_examples_package}
@@ -99,10 +99,13 @@ Tizen Web APIs system info demo implementation using Crosswalk.
 %setup -q
 
 cp %{SOURCE1001} .
+cp %{SOURCE1} .
 cp %{SOURCE2} .
 cp %{SOURCE3} .
 cp %{SOURCE4} .
 cp %{SOURCE5} .
+
+sed "s|@LIB_INSTALL_DIR@|%{_libdir}|g" %{name}.in > %{name}
 
 %build
 
@@ -122,7 +125,7 @@ make %{?_smp_mflags}
 %install
 
 # Binary wrapper.
-install -m 755 -D %{SOURCE1} %{buildroot}%{_bindir}/%{name}
+install -m 755 -D %{name} %{buildroot}%{_bindir}/%{name}
 install -m 755 -D %{SOURCE3} %{buildroot}%{_bindir}/%{_bluetooth_demo_package}
 install -m 755 -D %{SOURCE4} %{buildroot}%{_bindir}/%{_examples_package}
 install -m 755 -D %{SOURCE5} %{buildroot}%{_bindir}/%{_system_info_demo_package}


### PR DESCRIPTION
The TEC extensions libraries are delivered into different directory
varies 32-bit (/usr/lib) and 64-bit (/usr/lib64), the script need
to aware this difference.

BUG=XWALK-1624
