### PR TITLE
Clean up GCC warnings

### DIFF
--- a/application/application_manager.cc
+++ b/application/application_manager.cc
@@ -158,7 +158,6 @@ picojson::value* ApplicationManager::KillApp(const std::string& context_id) {
 }
 
 picojson::value* ApplicationManager::LaunchApp(const std::string& app_id) {
-  WebApiAPIErrors error = WebApiAPIErrors::NO_ERROR;
   int ret = aul_open_app(app_id.c_str());
   if (ret < 0) {
     switch (ret) {

--- a/filesystem/filesystem_instance.cc
+++ b/filesystem/filesystem_instance.cc
@@ -96,12 +96,13 @@ bool makePath(const std::string& path) {
 
     // If path doesn't exist, try to create one and continue iteration.
     // In case of error, stop iteration and return.
-    if (stat(new_path.c_str(), &st) != 0)
+    if (stat(new_path.c_str(), &st) != 0) {
       if (mkdir(new_path.c_str(), kDefaultFileMode) != 0 && errno != EEXIST )
           return false;
     // If path exists and it is not a directory, stop iteration and return.
-    else if (!S_ISDIR(st.st_mode))
+    } else if (!S_ISDIR(st.st_mode)) {
       return false;
+    }
 
     // Advance iterator and create next parent folder.
     iter = cur_iter;
@@ -979,11 +980,14 @@ int DecodeOne(char c) {
 
 std::string ConvertFrom(std::string input) {
   std::string decoded;
-  int input_len = input.length(), decoded_bits = 0, c, i;
+  int input_len = input.length();
 
   if (input_len % 4)
     return input;
 
+  int i;
+  int c = 0;
+  int decoded_bits = 0;
   for (i = 0; i < input_len;) {
     c = input[i++];
     if (c == '=')

--- a/mediaserver/mediaserver.cc
+++ b/mediaserver/mediaserver.cc
@@ -427,7 +427,7 @@ void MediaServer::postResult(
   picojson::array json_objects;
 
   g_variant_iter_init(&it, objects);
-  while (variant = g_variant_iter_next_value(&it)) {
+  while ((variant = g_variant_iter_next_value(&it))) {
     json_objects.push_back(mediaObjectToJSON(variant));
     g_variant_unref(variant);
   }
@@ -509,7 +509,7 @@ void MediaServer::OnCreateFolder(
     GAsyncResult *res,
     double async_id) {
   GError* gerror = NULL;
-  gchar **out_Paths;
+  gchar **out_Paths = NULL;
 
   if (dleyna_media_device_call_create_container_in_any_container_finish(
       mediadevice_proxy_,
@@ -530,7 +530,7 @@ void MediaServer::OnUpload(
     double async_id) {
   GError* gerror = NULL;
   guint upload_id;
-  gchar **out_Path;
+  gchar **out_Path = NULL;
 
   if (dleyna_media_device_call_upload_to_any_container_finish(
       mediadevice_proxy_,
@@ -553,7 +553,7 @@ void MediaServer::OnUploadToContainer(
     double async_id) {
   GError* gerror = NULL;
   guint out_UploadId;
-  gchar **out_Path;
+  gchar **out_Path = NULL;
 
   if (upnp_media_container2_call_upload_finish(
       reinterpret_cast<upnpMediaContainer2*>(source_object),
@@ -577,7 +577,7 @@ void MediaServer::OnCreateFolderInContainer(
     GAsyncResult *res,
     double async_id) {
   GError* gerror = NULL;
-  gchar **out_Path;
+  gchar **out_Path = NULL;
 
   if (upnp_media_container2_call_create_container_finish(
       reinterpret_cast<upnpMediaContainer2*>(source_object),

--- a/network_bearer_selection/network_bearer_selection_connection_tizen.cc
+++ b/network_bearer_selection/network_bearer_selection_connection_tizen.cc
@@ -206,19 +206,6 @@ void NetworkBearerSelectionConnection::ReleaseRouteToHost(
 
 connection_profile_h NetworkBearerSelectionConnection::GetProfileForNetworkType(
     NetworkType network_type) {
-  // FIXME(tmpsantos): I'm not really sure if we should really map the UNKNOWN
-  // type to the wireless. Looks to me that it should have its own category,
-  // although the spec doesn't say anything about it.
-  connection_profile_type_e expected_profile_type;
-  switch (network_type) {
-    case CELLULAR:
-      expected_profile_type = CONNECTION_PROFILE_TYPE_CELLULAR;
-      break;
-    case UNKNOWN:
-      expected_profile_type = CONNECTION_PROFILE_TYPE_WIFI;
-      break;
-  }
-
   connection_profile_iterator_h profile_iter;
   int ret = connection_get_profile_iterator(connection_,
                                             CONNECTION_ITERATOR_TYPE_REGISTERED,
@@ -234,7 +221,15 @@ connection_profile_h NetworkBearerSelectionConnection::GetProfileForNetworkType(
 
     connection_profile_type_e profile_type;
     connection_profile_get_type(profile, &profile_type);
-    if (profile_type == expected_profile_type)
+
+    // FIXME(tmpsantos): I'm not really sure if we should really map the UNKNOWN
+    // type to the wireless. Looks to me that it should have its own category,
+    // although the spec doesn't say anything about it.
+    connection_profile_type_e expected_type = CONNECTION_PROFILE_TYPE_WIFI;
+    if (network_type == CELLULAR)
+      expected_type = CONNECTION_PROFILE_TYPE_CELLULAR;
+
+    if (profile_type == expected_type)
       return profile;
   }
 

--- a/system_setting/system_setting_instance_tizen.cc
+++ b/system_setting/system_setting_instance_tizen.cc
@@ -13,7 +13,7 @@ void SystemSettingInstance::HandleSetProperty(const picojson::value& msg) {
     (msg.get("_type").get<double>());
   const char* value = msg.get("_file").to_str().c_str();
   const char* reply_id = msg.get("_reply_id").to_str().c_str();
-  system_settings_key_e key;
+  system_settings_key_e key = SYSTEM_SETTINGS_KEY_INCOMING_CALL_RINGTONE;
   switch (type) {
     case HOME_SCREEN:
       key = SYSTEM_SETTINGS_KEY_WALLPAPER_HOME_SCREEN;
@@ -27,9 +27,9 @@ void SystemSettingInstance::HandleSetProperty(const picojson::value& msg) {
     case NOTIFICATION_EMAIL:
       key = SYSTEM_SETTINGS_KEY_EMAIL_ALERT_RINGTONE;
       break;
-  default:
-    std::cout<< "Invalid Key : should not reach here";
-    break;
+    default:
+      std::cout<< "Invalid Key : should not reach here";
+      break;
   }
 
   int ret = system_settings_set_value_string(key, value);
@@ -40,7 +40,7 @@ void SystemSettingInstance::HandleGetProperty(const picojson::value& msg) {
   SystemSettingType type = static_cast<SystemSettingType>
     (msg.get("_type").get<double>());
   const char* reply_id = msg.get("_reply_id").to_str().c_str();
-  system_settings_key_e key;
+  system_settings_key_e key = SYSTEM_SETTINGS_KEY_INCOMING_CALL_RINGTONE;
   switch (type) {
     case HOME_SCREEN:
       key = SYSTEM_SETTINGS_KEY_WALLPAPER_HOME_SCREEN;


### PR DESCRIPTION
These warnings are only visible on 64-bit build because -Wall is added
into CFLAGS, while 32-bit build does not. The summary of the warnigns:
- unused-variable
- maybe-uninitialized
- parentheses
- uninitialized
