### PR TITLE
[power] throw an exception instead of blocking forever

### DIFF
--- a/examples/power.html
+++ b/examples/power.html
@@ -79,13 +79,19 @@ shouldThrow("tizen.power.release('MOUSE')", "new tizen.WebAPIException(tizen.Web
 shouldNotThrow("tizen.power.release('CPU')");
 shouldNotThrow("tizen.power.release('SCREEN')");
 
-var screenBrightness = tizen.power.getScreenBrightness();
 shouldThrow("tizen.power.setScreenBrightness('1')", "new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR)");
 shouldThrow("tizen.power.setScreenBrightness(2)", "new tizen.WebAPIException(tizen.WebAPIException.INVALID_VALUES_ERR)");
-tizen.power.setScreenBrightness(0.5);
 
-tizen.power.restoreScreenBrightness();
-shouldBeTrue("tizen.power.getScreenBrightness() == screenBrightness");
+try { // these are synchronous APIs that may throw exceptions
+  var screenBrightness = tizen.power.getScreenBrightness();
+  tizen.power.setScreenBrightness(0.5);
+  tizen.power.restoreScreenBrightness();
+  shouldBeTrue("tizen.power.getScreenBrightness() == screenBrightness");
+} catch (serr){
+  debug("Error when accessing screen brightness API: " + serr.name);
+}
+
+
 setTimeout(waitForRestore, 1000);
 
 var previousState = "";

--- a/power/power_api.js
+++ b/power/power_api.js
@@ -138,9 +138,14 @@ exports.unsetScreenStateChangeListener = function() {
 };
 
 exports.getScreenBrightness = function() {
-  var brightness = parseFloat(sendSyncMessage({
+  var r = JSON.parse(sendSyncMessage({
     'cmd': 'PowerGetScreenBrightness'
   }));
+  if (r['error']){
+    throw new tizen.WebAPIException(tizen.WebAPIException.NOT_SUPPORTED_ERR);
+    return;
+  }
+  var brightness = r['brightness'];
   if (defaultScreenBrightness === undefined)
     defaultScreenBrightness = brightness;
   return brightness;

--- a/power/power_instance_tizen.cc
+++ b/power/power_instance_tizen.cc
@@ -221,16 +221,24 @@ void PowerInstanceMobile::HandleGetScreenState() {
 
 void PowerInstanceMobile::HandleGetScreenBrightness() {
   int platformBrightness;
+  picojson::value::object o;
+
   int ret = device_get_brightness(0, &platformBrightness);
   if (ret != 0) {
     fprintf(stderr, "Can't get the brightness from the platform. \n");
-    return;
+    o["error"] = picojson::value("Can't get the brightness from the platform.");
+  } else {
+    int maxBrightness;
+    ret = device_get_max_brightness(0, &maxBrightness);
+    if (ret != 0 || maxBrightness <= 0) {
+      fprintf(stderr, "Can't get the max brightness from the platform. \n");
+      maxBrightness = 100;
+    }
+    double brightness = platformBrightness / maxBrightness;
+    o["brightness"] = picojson::value(brightness);
   }
-
-  double brightness = platformBrightness / 100.0;
-  char brightnessAsString[32];
-  snprintf(brightnessAsString, sizeof(brightnessAsString), "%g", brightness);
-  SendSyncReply(brightnessAsString);
+  picojson::value v(o);
+  SendSyncReply(v.serialize().c_str());
 }
 
 void PowerInstanceMobile::HandleSetScreenEnabled(const picojson::value& msg) {


### PR DESCRIPTION
In synchronous calls, throw an exception instead of blocking
forever when the underlying system API returns an error.
Modified example to show usage.

BUG=XWALK-1390
