### PR TITLE
Fix the desktop build after 0c5d1dc.

### DIFF
--- a/common/common.gypi
+++ b/common/common.gypi
@@ -18,7 +18,12 @@
         'includes/': [['exclude', '_desktop\\.gypi$|desktop/']],
       }],
       ['tizen == 1', {
-        'defines': ['TIZEN']
+        'defines': ['TIZEN'],
+        'variables': {
+          'packages': [
+            'libtzplatform-config',
+          ],
+        },
       }, {
         'sources/': [['exclude', '_tizen\\.cc$|tizen/']],
         'includes/': [['exclude', '_tizen\\.gypi$|tizen/']],
@@ -74,10 +79,5 @@
       '-fPIC',
       '-fvisibility=hidden',
     ],
-    'variables': {
-      'packages': [
-        'libtzplatform-config',
-      ],
-    },
   },
 }


### PR DESCRIPTION
Depend on libtzplatform-config only for Tizen builds, as it does not exist elsewhere.
