### PR TITLE
Fix build issue on desktop.

### DIFF
--- a/common/common.gypi
+++ b/common/common.gypi
@@ -16,6 +16,11 @@
       ['extension_host_os != "desktop"', {
         'sources/': [['exclude', '_desktop\\.cc$|desktop/']],
         'includes/': [['exclude', '_desktop\\.gypi$|desktop/']],
+        'variables': {
+          'packages': [
+            'libtzplatform-config',
+          ],
+        },
       }],
       ['tizen == 1', {
         'defines': ['TIZEN']
@@ -74,10 +79,5 @@
       '-fPIC',
       '-fvisibility=hidden',
     ],
-    'variables': {
-      'packages': [
-        'libtzplatform-config',
-      ],
-    },
   },
 }

--- a/system_info/system_info_utils.cc
+++ b/system_info/system_info_utils.cc
@@ -5,7 +5,9 @@
 #include "system_info/system_info_utils.h"
 
 #include <stdio.h>
+#if defined(TIZEN)
 #include <tzplatform_config.h>
+#endif
 #include <unistd.h>
 
 #include <algorithm>
@@ -20,6 +22,7 @@ const char kDuid_str_key[] = "http://tizen.org/system/duid";
 
 namespace system_info {
 
+#if defined(TIZEN)
 char* GetDuidProperty() {
   char *s = NULL;
   FILE *fp = NULL;
@@ -45,6 +48,7 @@ char* GetDuidProperty() {
   }
   return s;
 }
+#endif
 
 int ReadOneByte(const char* path) {
   FILE* fp = fopen(path, "r");

--- a/system_info/system_info_utils.h
+++ b/system_info/system_info_utils.h
@@ -24,7 +24,9 @@ namespace system_info {
 
 // The default timeout interval is set to 1s to match the top update interval.
 const int default_timeout_interval = 1000;
+#if defined(TIZEN)
 char* GetDuidProperty();
+#endif
 int ReadOneByte(const char* path);
 // Free the returned value after using.
 char* ReadOneLine(const char* path);


### PR DESCRIPTION
libtzplatform-config dependency is introduced by commit 0c5d1dc2, it
should be under Tizen profile only, otherwise desktop will fail to
configure.
