### PR TITLE
Fix XWALK-1837: include callhistory only in Tizen mobile target

### DIFF
--- a/tizen-wrt.gyp
+++ b/tizen-wrt.gyp
@@ -25,11 +25,15 @@
           'dependencies': [
             'application/application.gyp:*',
             'bookmark/bookmark.gyp:*',
-            'callhistory/callhistory.gyp:*',
             'content/content.gyp:*',
             'download/download.gyp:*',
             'filesystem/filesystem.gyp:*',
             'messageport/messageport.gyp:*',
+          ],
+        }],
+        [ 'extension_host_os == "mobile"', {
+          'dependencies': [
+            'callhistory/callhistory.gyp:*',
           ],
         }],
       ],


### PR DESCRIPTION
The callhistory extension should only be in the "mobile" target, not in "tizen" in general.
