### PR TITLE
[Bluetooth] Init tizen capi backend in BluetoothInstance

### DIFF
--- a/bluetooth/bluetooth_extension.cc
+++ b/bluetooth/bluetooth_extension.cc
@@ -5,17 +5,12 @@
 #include "bluetooth/bluetooth_extension.h"
 
 #if defined(TIZEN_CAPI_BT)
-#include <bluetooth.h>
 #include "bluetooth/bluetooth_instance_capi.h"
 #else
 #include "bluetooth/bluetooth_instance.h"
 #endif
 
 common::Extension* CreateExtension() {
-#if defined(TIZEN_CAPI_BT)
-  CAPI(bt_initialize());
-#endif
-
   return new BluetoothExtension;
 }
 

--- a/bluetooth/bluetooth_instance_capi.cc
+++ b/bluetooth/bluetooth_instance_capi.cc
@@ -38,6 +38,7 @@ BluetoothInstance::BluetoothInstance()
   event_thread = pthread_create(&event_thread, &thread_attr,
       event_loop, NULL);
 
+  CAPI(bt_initialize());
   InitializeAdapter();
 }
 


### PR DESCRIPTION
It was previously done at the extension creation step and
it prevented from performing TCT bluetooth tests.
