### PR TITLE
[AudioSystem] Made audiosystem extension IVI specific.

### DIFF
--- a/tizen-wrt.gyp
+++ b/tizen-wrt.gyp
@@ -26,7 +26,6 @@
           'dependencies': [
             'alarm/alarm.gyp:*',
             'application/application.gyp:*',
-            'audiosystem/audiosystem.gyp:*',
             'bookmark/bookmark.gyp:*',
             'content/content.gyp:*',
             'download/download.gyp:*',
@@ -41,6 +40,7 @@
         }],
         [ 'extension_host_os == "ivi"', {
           'dependencies': [
+            'audiosystem/audiosystem.gyp:*',
             'vehicle/vehicle.gyp:*',
           ],
         }],


### PR DESCRIPTION
AudioSystem API is not part of Tizen Common, it was intended only for Tizen IVI.
Hence moving under 'ivi' check.
