### PR TITLE
[Bluetooth] stopDiscovery API fix

### DIFF
--- a/bluetooth/bluetooth_instance_capi.cc
+++ b/bluetooth/bluetooth_instance_capi.cc
@@ -562,9 +562,15 @@ void BluetoothInstance::HandleStopDiscovery(const picojson::value& msg) {
 
   bool is_discovering = false;
   CAPI(bt_adapter_is_discovering(&is_discovering));
-  if (!is_discovering)
+  if (!is_discovering) {
+    picojson::value::object o;
+    o["error"] = picojson::value(static_cast<double>(1));
+    o["cmd"] = picojson::value("");
+    o["reply_id"] = picojson::value(callbacks_id_map_["StopDiscovery"]);
+    callbacks_id_map_.erase("StopDiscovery");
+    InternalPostMessage(picojson::value(o));
     return;
-
+  }
   stop_discovery_from_js_ = true;
   CAPI(bt_adapter_stop_device_discovery());
 }


### PR DESCRIPTION
Return an error message to javascript when there is no discovering
when user requests to stop it.
