### PR TITLE
[Alarm] Initialize the "period" to null if its value is not set.

### DIFF
--- a/alarm/alarm_api.js
+++ b/alarm/alarm_api.js
@@ -87,12 +87,14 @@ tizen.AlarmAbsolute = function(date, periodOrDaysOfWeek) {
     throw new tizen.WebAPIException(tizen.WebAPIException.TYPE_MISMATCH_ERR);
   }
 
+  var periodValue = null;
   var daysOfTheWeek = [];
   if (typeof periodOrDaysOfWeek === 'number' && !isNaN(periodOrDaysOfWeek)) {
-    defineReadOnlyProperty(this, 'period', periodOrDaysOfWeek);
+    periodValue = periodOrDaysOfWeek;
   } else if (periodOrDaysOfWeek instanceof Array && periodOrDaysOfWeek.length > 0) {
     daysOfTheWeek = periodOrDaysOfWeek;
   }
+  defineReadOnlyProperty(this, 'period', periodValue);
   defineReadOnlyProperty(this, 'daysOfTheWeek', daysOfTheWeek);
 };
 
@@ -124,6 +126,8 @@ tizen.AlarmRelative = function(delay, period) {
 
   if (typeof period === 'number' && !isNaN(period))
     defineReadOnlyProperty(this, 'period', period);
+  else
+    defineReadOnlyProperty(this, 'period', null);
 };
 
 tizen.AlarmRelative.prototype = new tizen.Alarm();


### PR DESCRIPTION
Explicitly set null to the property "period" if period input value is not set. This can ensure the property "period" is always enumerable.

BUG=XWALK-2079
