### PR TITLE
[Alarm] Initialize the "id" to null in constructor

### DIFF
--- a/alarm/alarm_api.js
+++ b/alarm/alarm_api.js
@@ -51,8 +51,10 @@ function flagToDaysOfWeek(flag) {
   return days;
 }
 
-function defineReadOnlyProperty(object, key, value) {
+function defineReadOnlyProperty(object, key, value, configurable) {
+  configurable = configurable || false;
   Object.defineProperty(object, key, {
+    configurable: configurable,
     enumerable: true,
     writable: false,
     value: value
@@ -75,7 +77,10 @@ defineReadOnlyProperty(exports, 'PERIOD_HOUR', 3600);
 defineReadOnlyProperty(exports, 'PERIOD_DAY', 86400);
 defineReadOnlyProperty(exports, 'PERIOD_WEEK', 604800);
 
-tizen.Alarm = function() {};
+tizen.Alarm = function() {
+  // set configurable as true so that this property can be re-defined in sub class
+  defineReadOnlyProperty(this, 'id', null, true);
+};
 tizen.Alarm.prototype.constructor = tizen.Alarm;
 
 tizen.AlarmAbsolute = function(date, periodOrDaysOfWeek) {


### PR DESCRIPTION
The alarm id becomes valid only when it's added into tizen system.
Before that we should ensure the property is enumerable.
Set the configurable to true because we can re-define the property later in sub class when it's added into tizen system.

BUG=XWALK-2127
