### PR TITLE
recalculate dpi on different platform

### DIFF
--- a/system_info/system_info_display.h
+++ b/system_info/system_info_display.h
@@ -60,6 +60,7 @@ class SysInfoDisplay : public SysInfoObject {
   double physical_height_;
   double brightness_;
   int timeout_cb_id_;
+  int scale_factor_;
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoDisplay);
 };


### PR DESCRIPTION
The scale `factor` will always be 1 if the output scale does not change. So I default set `factor` to 1. If the event happens, the listener will get the latest scale and recalculate dpi.
