### PR TITLE
Upgrade after crosswalk always use tizen_app_id on tizen, fix cannot get current app info and dbus proxy.

### DIFF
--- a/application/application.h
+++ b/application/application.h
@@ -17,7 +17,7 @@ class ApplicationInformation;
 // This class will represent the current application running this extension.
 class Application {
  public:
-  explicit Application(const std::string& pkg_id);
+  explicit Application(const std::string& app_id);
   ~Application();
 
   const std::string GetAppId();
@@ -30,10 +30,7 @@ class Application {
   const std::string Serialize();
 
  private:
-  bool RetrieveAppId();
-
   std::string app_id_;
-  std::string pkg_id_;
   GDBusProxy* running_app_proxy_;
 };
 

--- a/application/application_extension.cc
+++ b/application/application_extension.cc
@@ -13,12 +13,7 @@
 #include "common/picojson.h"
 
 common::Extension* CreateExtension() {
-  // For xpk, tizen_app_id = xwalk.package_id;
-  //          package_id = crosswalk_32bytes_app_id;
-  // For wgt, tizen_app_id = package_id.app_name,
-  //          package_id = tizen_wrt_10bytes_package_id;
-  std::string id_str =
-      common::Extension::GetRuntimeVariable("tizen_app_id", 64);
+  std::string id_str = common::Extension::GetRuntimeVariable("app_id", 64);
   picojson::value id_val;
   std::istringstream buf(id_str);
   std::string error = picojson::parse(id_val, buf);
@@ -27,27 +22,21 @@ common::Extension* CreateExtension() {
     return NULL;
   }
 
-  std::string tizen_app_id = id_val.get<std::string>();
-  if (tizen_app_id.empty()) {
+  std::string app_id = id_val.get<std::string>();
+  if (app_id.empty()) {
     std::cerr << "Application extension will not be created without "
               << "application context." << std::endl;
     return NULL;
   }
 
-  std::string pkg_id;
-  if (tizen_app_id.find("xwalk.") == 0)
-    pkg_id = tizen_app_id.substr(6);
-  else
-    pkg_id = tizen_app_id.substr(0, 10);
-
-  return new ApplicationExtension(pkg_id);
+  return new ApplicationExtension(app_id);
 }
 
 // This will be generated from application_api.js
 extern const char kSource_application_api[];
 
-ApplicationExtension::ApplicationExtension(const std::string& pkg_id) {
-  current_app_.reset(new Application(pkg_id));
+ApplicationExtension::ApplicationExtension(const std::string& app_id) {
+  current_app_.reset(new Application(app_id));
   app_manager_.reset(new ApplicationManager());
 
   SetExtensionName("tizen.application");

--- a/application/application_information.cc
+++ b/application/application_information.cc
@@ -257,30 +257,7 @@ void RetrieveAllInstalledAppInfo(picojson::array& data,
     SetErrorMessage(error, "get_all");
 }
 
-int PkgIdToAppIdCallback(const pkgmgr_appinfo_h handle, void* user_data) {
-  char* app_id = NULL;
-  if (pkgmgr_appinfo_get_appid(handle, &app_id) != PMINFO_R_OK)
-    return 0;
-
-  std::string* data = static_cast<std::string*>(user_data);
-  (*data) = app_id;
-  return 0;
-}
-
 }  // namespace
-
-std::string ApplicationInformation::PkgIdToAppId(const std::string& pkg_id) {
-  pkgmgrinfo_pkginfo_h pkginfo_handle;
-  int ret = pkgmgrinfo_pkginfo_get_pkginfo(pkg_id.c_str(), &pkginfo_handle);
-  if (ret != PMINFO_R_OK)
-    return "";
-
-  std::string app_id;
-  // By now, we only have UI Crosswalk application.
-  pkgmgr_appinfo_get_list(
-      pkginfo_handle, PM_UI_APP, &PkgIdToAppIdCallback, &app_id);
-  return app_id;
-}
 
 picojson::value* ApplicationInformation::GetAllInstalled() {
   picojson::array data;

--- a/application/application_information.h
+++ b/application/application_information.h
@@ -15,9 +15,6 @@
 // failure reason.
 class ApplicationInformation {
  public:
-  // Translate app's package ID to application ID, only valid for XWalk apps.
-  static std::string PkgIdToAppId(const std::string& pkg_id);
-
   // Returns a object type value to caller. When success its "data" field will
   // contains an app info array. When fail its "error" field will contains error
   // info.

--- a/filesystem/filesystem_instance.cc
+++ b/filesystem/filesystem_instance.cc
@@ -125,23 +125,6 @@ int get_dir_entry_count(const char* path) {
   return count;
 }
 
-std::string GetAppId(const std::string& package_id) {
-  char* appid = NULL;
-  pkgmgrinfo_pkginfo_h pkginfo_handle;
-  int ret = pkgmgrinfo_pkginfo_get_pkginfo(package_id.c_str(), &pkginfo_handle);
-  if (ret != PMINFO_R_OK)
-    return std::string();
-  ret = pkgmgrinfo_pkginfo_get_mainappid(pkginfo_handle, &appid);
-  if (ret != PMINFO_R_OK) {
-    pkgmgrinfo_pkginfo_destroy_pkginfo(pkginfo_handle);
-    return std::string();
-  }
-
-  std::string retval(appid);
-  pkgmgrinfo_pkginfo_destroy_pkginfo(pkginfo_handle);
-  return retval;
-}
-
 std::string GetExecPath(const std::string& app_id) {
   char* exec_path = NULL;
   pkgmgrinfo_appinfo_h appinfo_handle;
@@ -169,20 +152,17 @@ std::string GetApplicationPath() {
     return std::string();
   }
 
-  std::string pkg_id = id_val.get<std::string>();
-  if (pkg_id.empty())
-    return std::string();
-
-  std::string app_id = GetAppId(pkg_id);
+  std::string app_id = id_val.get<std::string>();
   if (app_id.empty())
     return std::string();
+
   std::string exec_path = GetExecPath(app_id);
   if (exec_path.empty())
     return std::string();
 
-  size_t index = exec_path.find(pkg_id);
+  size_t index = exec_path.find(app_id);
   if (index != std::string::npos)
-    return exec_path.substr(0, index + pkg_id.length());
+    return exec_path.substr(0, index + app_id.length());
   return std::string();
 }
 


### PR DESCRIPTION
Upgrade after crosswalk always use tizen_app_id on tizen, fix cannot get current app info and dbus proxy.

PR#2261 : https://github.com/crosswalk-project/crosswalk/pull/2261

After PR#2261, we always get the app_id which will equal to the
app_id storaged in pkgmgr DB, so there is no need to convert
pkg_id to app_id.

Because object path with '.' is an invalid object path, so
after PR#2261 the object path of running application on dbus
was changed so we need to change it too.

BUG=XWALK-1925
