### PR TITLE
Remove worker threads from media renderer api implementation.

### DIFF
--- a/media_renderer/media_renderer_instance.h
+++ b/media_renderer/media_renderer_instance.h
@@ -5,9 +5,6 @@
 #ifndef MEDIA_RENDERER_MEDIA_RENDERER_INSTANCE_H_
 #define MEDIA_RENDERER_MEDIA_RENDERER_INSTANCE_H_
 
-#include <glib.h>
-#include <thread>  // NOLINT
-
 #include "common/extension.h"
 
 class MediaRendererManager;
@@ -24,14 +21,10 @@ class MediaRendererInstance : public common::Instance {
   virtual ~MediaRendererInstance();
 
  private:
-  void InitWorkerThread();
-  static gboolean CreateMediaRendererManager(void* data);
   // common::Instance implementation.
   virtual void HandleMessage(const char* msg);
   virtual void HandleSyncMessage(const char* msg);
 
-  std::thread worker_thread_;
-  GMainLoop* worker_loop_ = NULL;
   MediaRendererManager* media_renderer_manager_ = NULL;
 };
 


### PR DESCRIPTION
This causes random crash while starting up. Now on create the manager
on the main loop directly.

BUG=XWALK-2276
