### PR TITLE
Remove redunant dependency of libgsignon-glib

### DIFF
--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -76,8 +76,6 @@ BuildRequires: python
 Requires:      crosswalk
 # For Content API
 Requires:      media-thumbnail-server
-# For SSO API
-Requires:      libgsignon-glib
 
 %description
 Tizen Web APIs implemented using Crosswalk.


### PR DESCRIPTION
pbgsignon-glib dependency is already added by
pkgconfig(libgsignon-glib), so there is no need to add
Requires:libgsignon-glib explicitly.
