### PR TITLE
run examples and demos with xwalk-launcher

### DIFF
--- a/packaging/tizen-extensions-crosswalk-audiosystem-demo
+++ b/packaging/tizen-extensions-crosswalk-audiosystem-demo
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec /usr/bin/tizen-extensions-crosswalk /usr/share/tizen-extensions-crosswalk/demos/audiosystem/index.html
+exec /usr/bin/xwalk-launch file:///usr/share/tizen-extensions-crosswalk/demos/audiosystem/index.html

--- a/packaging/tizen-extensions-crosswalk-bluetooth-demo
+++ b/packaging/tizen-extensions-crosswalk-bluetooth-demo
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec /usr/bin/tizen-extensions-crosswalk /usr/share/tizen-extensions-crosswalk/demos/tizen/bluetooth.html
+exec /usr/bin/xwalk-launch file:///usr/share/tizen-extensions-crosswalk/demos/tizen/bluetooth.html

--- a/packaging/tizen-extensions-crosswalk-examples
+++ b/packaging/tizen-extensions-crosswalk-examples
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec /usr/bin/tizen-extensions-crosswalk /usr/share/tizen-extensions-crosswalk/examples/index.html
+exec /usr/bin/xwalk-launcher file:///usr/share/tizen-extensions-crosswalk/examples/index.html

--- a/packaging/tizen-extensions-crosswalk-system-info-demo
+++ b/packaging/tizen-extensions-crosswalk-system-info-demo
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec /usr/bin/tizen-extensions-crosswalk /usr/share/tizen-extensions-crosswalk/demos/system_info/system_info.html
+exec /usr/bin/xwalk-launch file:///usr/share/tizen-extensions-crosswalk/demos/system_info/system_info.html

--- a/packaging/tizen-extensions-crosswalk.in
+++ b/packaging/tizen-extensions-crosswalk.in
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-if [ ! -f /usr/bin/xwalk ]; then
-   echo "The xwalk binary could not be found. Exiting."
-   exit 1
-fi
-
-exec /usr/bin/xwalk --allow-external-extensions-for-remote-sources --external-extensions-path=@LIB_INSTALL_DIR@/tizen-extensions-crosswalk "$@"

--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -15,7 +15,6 @@ Group:      Development/Libraries
 Summary:    Tizen Web APIs implemented using Crosswalk
 URL:        https://github.com/otcshare/tizen-extensions-crosswalk
 Source0:    %{name}-%{version}.tar.gz
-Source1:    %{name}.in
 Source2:    %{name}.png
 Source3:    %{_bluetooth_demo_package}
 Source4:    %{_examples_package}
@@ -116,13 +115,10 @@ Sample Tizen volume control application that demonstrates the Tizen AudioSystem 
 %setup -q
 
 cp %{SOURCE1001} .
-cp %{SOURCE1} .
 cp %{SOURCE2} .
 cp %{SOURCE3} .
 cp %{SOURCE4} .
 cp %{SOURCE5} .
-
-sed "s|@LIB_INSTALL_DIR@|%{_libdir}|g" %{name}.in > %{name}
 
 %build
 
@@ -142,7 +138,6 @@ ninja -C out/Default %{?_smp_mflags}
 %install
 
 # Binary wrapper.
-install -m 755 -D %{name} %{buildroot}%{_bindir}/%{name}
 install -m 755 -D %{SOURCE3} %{buildroot}%{_bindir}/%{_bluetooth_demo_package}
 install -m 755 -D %{SOURCE4} %{buildroot}%{_bindir}/%{_examples_package}
 install -m 755 -D %{SOURCE5} %{buildroot}%{_bindir}/%{_system_info_demo_package}
@@ -208,7 +203,6 @@ install -p -D %{name}.png %{buildroot}%{_desktop_icondir}/%{_audiosystem_demo_pa
 %files
 # TODO(rakuco): This causes problems on 2.1 when creating the package.
 # %license LICENSE
-%{_bindir}/%{name}
 %{_libdir}/%{name}/libtizen*.so
 
 %files -n %{_bluetooth_demo_package}


### PR DESCRIPTION
As /usr/bin/xwalk binary doesn't exist anymore, we can not launch
examples and demos from xwalk binary.

BUG=XWALK-2370
