### PR TITLE
two bluetooth bugs

### DIFF
--- a/bluetooth/bluetooth_api.js
+++ b/bluetooth/bluetooth_api.js
@@ -892,11 +892,10 @@ BluetoothDevice.prototype.connectToServiceByUUID =
       return;
     }
 
-    if (socketSuccessCallback) {
-      var i = adapter.indexOfDevice(adapter.known_devices, result.peer);
-      var socket_cb = new BluetoothSocket(result.uuid, adapter.known_devices[i], result);
-      socketSuccessCallback(socket_cb);
-    }
+    var i = adapter.indexOfDevice(adapter.known_devices, result.peer);
+    var socket = new BluetoothSocket(result.uuid, adapter.known_devices[i], result);
+    adapter.sockets.push(socket);
+    socketSuccessCallback(socket);
   });
 };
 


### PR DESCRIPTION
1. BluetoothSocket object doesn't have 'isConnected' property
2. Socket should be stored in adapter object after creation
   concerns TCT test cases :
   - BluetoothSocket_onmessage_callback
   - BluetoothSocket_readData
