### PR TITLE
[Bluetooth] fix initialization in IVI and getDefaultAdapter()

### DIFF
--- a/bluetooth/bluetooth_api.js
+++ b/bluetooth/bluetooth_api.js
@@ -394,22 +394,23 @@ _addConstProperty(exports, 'deviceService', exports.deviceService);
 var defaultAdapter = new BluetoothAdapter();
 
 exports.getDefaultAdapter = function() {
-  var msg = {
-    'cmd': 'GetDefaultAdapter'
-  };
-  var result = JSON.parse(extension.internal.sendSyncMessage(JSON.stringify(msg)));
+  if (!defaultAdapter.name) {
+    var msg = { 'cmd': 'GetDefaultAdapter' };
 
-  if (!result.error) {
-    _addConstProperty(defaultAdapter, 'name', result.name);
-    _addConstProperty(defaultAdapter, 'address', result.address);
-    _addConstProperty(defaultAdapter, 'powered', result.powered);
-    _addConstProperty(defaultAdapter, 'visible', result.visible);
+    var result = JSON.parse(extension.internal.sendSyncMessage(JSON.stringify(msg)));
 
-    if (result.hasOwnProperty('address') && result.address != '')
-      adapter.isReady = true;
-  } else {
-    adapter.isReady = false;
-    throw new tizen.WebAPIException(tizen.WebAPIException.UNKNOWN_ERR);
+    if (!result.error) {
+      _addConstProperty(defaultAdapter, 'name', result.name);
+      _addConstProperty(defaultAdapter, 'address', result.address);
+      _addConstProperty(defaultAdapter, 'powered', result.powered);
+      _addConstProperty(defaultAdapter, 'visible', result.visible);
+
+      if (result.hasOwnProperty('address') && result.address != '')
+        adapter.isReady = true;
+    } else {
+      adapter.isReady = false;
+      throw new tizen.WebAPIException(tizen.WebAPIException.UNKNOWN_ERR);
+    }
   }
 
   return defaultAdapter;

--- a/bluetooth/bluetooth_instance_capi.h
+++ b/bluetooth/bluetooth_instance_capi.h
@@ -125,7 +125,7 @@ class BluetoothInstance : public common::Instance {
 
   bool is_js_context_initialized_;
   bool adapter_enabled_;
-  bool js_reply_needed_;
+  bool get_default_adapter_;
   bool stop_discovery_from_js_;
 };
 


### PR DESCRIPTION
bluetooth-frwk doesn't handle correctly the case that the bluetooth is
powered and its framework is off. In that case, we call a hackish method
in order to start bt-service daemon via dbus service activation.

This patch also prevents from being blocked in getDefaultAdapter() method.

BUG=XWALK-2419
