### PR TITLE
packaging: use oma-ds-agent only for mobile profile

### DIFF
--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -46,6 +46,9 @@ BuildRequires: pkgconfig(automotive-message-broker)
 BuildRequires: pkgconfig(capi-telephony-sim)
 BuildRequires: pkgconfig(contacts-service2)
 BuildRequires: pkgconfig(libpcrecpp)
+BuildRequires: pkgconfig(sync-agent)
+# For Datasync API
+Requires:      oma-ds-agent
 %endif
 BuildRequires: pkgconfig(capi-web-favorites)
 BuildRequires: pkgconfig(capi-web-url-download)
@@ -64,7 +67,6 @@ BuildRequires: pkgconfig(pkgmgr)
 BuildRequires: pkgconfig(pkgmgr-info)
 BuildRequires: pkgconfig(pmapi)
 BuildRequires: pkgconfig(tapi)
-BuildRequires: pkgconfig(sync-agent)
 BuildRequires: pkgconfig(vconf)
 %if %{with wayland}
 BuildRequires: pkgconfig(wayland-client)
@@ -76,8 +78,6 @@ BuildRequires: python
 Requires:      crosswalk
 # For Content API
 Requires:      media-thumbnail-server
-# For Datasync API
-Requires:      oma-ds-agent
 
 %description
 Tizen Web APIs implemented using Crosswalk.

--- a/tizen-wrt.gyp
+++ b/tizen-wrt.gyp
@@ -30,7 +30,6 @@
             'application/application.gyp:*',
             'bookmark/bookmark.gyp:*',
             'content/content.gyp:*',
-            'datasync/datasync.gyp:*',
             'download/download.gyp:*',
             'filesystem/filesystem.gyp:*',
             'messageport/messageport.gyp:*',
@@ -41,6 +40,7 @@
         [ 'extension_host_os == "mobile"', {
           'dependencies': [
             'callhistory/callhistory.gyp:*',
+            'datasync/datasync.gyp:*',
           ],
         }],
         [ 'extension_host_os == "ivi"', {


### PR DESCRIPTION
Tizen:Common and Tizen:IVI wont use it

More or less related to :
https://bugs.tizen.org/jira/browse/TC-1110
