### PR TITLE
[Systeminfo] T-e-c buildbreak on mobile profile

### DIFF
--- a/common/common.gypi
+++ b/common/common.gypi
@@ -12,6 +12,10 @@
         'sources/': [['exclude', '_mobile\\.cc$|mobile/']],
         'includes/': [['exclude', '_mobile\\.gypi$|mobile/']],
       }],
+      ['extension_host_os != "ivi"', {
+        'sources/': [['exclude', '_ivi\\.cc$|ivi/']],
+        'includes/': [['exclude', '_ivi\\.gypi$|ivi/']],
+      }],
       ['extension_host_os != "desktop"', {
         'sources/': [['exclude', '_desktop\\.cc$|desktop/']],
         'includes/': [['exclude', '_desktop\\.gypi$|desktop/']],

--- a/packaging/tizen-extensions-crosswalk.spec
+++ b/packaging/tizen-extensions-crosswalk.spec
@@ -41,7 +41,6 @@ BuildRequires: pkgconfig(libtzplatform-config)
 %if "%{profile}" == "ivi"
 BuildRequires: pkgconfig(automotive-message-broker)
 %endif
-# For IVI, it doesn't need sim package.
 %if "%{profile}" == "mobile"
 BuildRequires: pkgconfig(capi-telephony-sim)
 BuildRequires: pkgconfig(contacts-service2)

--- a/system_info/system_info_instance.cc
+++ b/system_info/system_info_instance.cc
@@ -69,7 +69,7 @@ void SystemInfoInstance::InstancesMapInitialize() {
   RegisterClass<SysInfoLocale>();
   RegisterClass<SysInfoNetwork>();
   RegisterClass<SysInfoPeripheral>();
-#if defined(TIZEN)
+#if defined(TIZEN_IVI) || defined(TIZEN_MOBILE)
   RegisterClass<SysInfoSim>();
 #endif
   RegisterClass<SysInfoStorage>();

--- a/system_info/system_info_sim.h
+++ b/system_info/system_info_sim.h
@@ -72,7 +72,7 @@ class SysInfoSim : public SysInfoObject {
                 unsigned int& member,
                 const unsigned int& default_value = 0);
   SystemInfoSimState GetSystemInfoSIMState(sim_state_e state);
-#else
+#elif defined(TIZEN_IVI)
   void InitDbusConnection();
   void DeInitDbusConnection();
   void GetSimProperties();
@@ -96,7 +96,7 @@ class SysInfoSim : public SysInfoObject {
   unsigned int mnc_;
   std::string msin_;
   std::string spn_;
-#if !defined(TIZEN_MOBILE)
+#if defined(TIZEN_IVI)
   GDBusConnection* conn_;
   guint prop_changed_watch_;
 #endif


### PR DESCRIPTION
This commit fixes buildbreak for mobile profile when using this configuration:
  gbs build -A armv7l --define="profile mobile" -R \
    http://download.tizen.org/snapshots/tizen/mobile/latest/repos/arm/packages/

Build configuration will include system_info_sim class for profiles - ivi and mobile.
System_info_sim will be excluded in common profile according to current
implementation of system_info_sim_ivi.cc and structure of SysSimInfo class.

BUG=XWALK-2861
