### PR TITLE
[Bluetooth] enable device disappeared event

### DIFF
--- a/bluetooth/bluetooth_instance_capi.cc
+++ b/bluetooth/bluetooth_instance_capi.cc
@@ -220,14 +220,12 @@ void BluetoothInstance::OnDiscoveryStateChanged(int result,
       obj->InternalPostMessage(picojson::value(o));
       break;
     }
-#ifdef NTB
     case BT_ADAPTER_DEVICE_DISCOVERY_REMOVED: {
       o["Address"] = picojson::value(discovery_info->remote_address);
       o["cmd"] = picojson::value("DeviceRemoved");
       obj->InternalPostMessage(picojson::value(o));
       break;
     }
-#endif
     default:
       LOG_ERR("Unknown discovery state callback!");
       break;


### PR DESCRIPTION
This feature was added in current Tizen bluetooth stack:
- platform/core/api/bluetooth : ea4787499cb21d2bfc744aad7b8ba103efe67845
- platform/core/connectivity/bluetooth-frwk : 9319c8e659d1194a7682350468da6c8fc6cd58cb

BUG=XWALK-2642
