### PR TITLE
[SysInfo] Fix inserting USB crash issue

### DIFF
--- a/system_info/system_info_storage.h
+++ b/system_info/system_info_storage.h
@@ -49,7 +49,7 @@ class SysInfoStorage : public SysInfoObject {
   void GetAllAvailableStorageDevices();
   void InitStorageMonitor();
   void QueryAllAvailableStorageUnits();
-  void MakeStorageUnit(SysInfoDeviceStorageUnit& unit, udev_device* dev) const;
+  bool MakeStorageUnit(SysInfoDeviceStorageUnit& unit, udev_device* dev) const;
   std::string ToStorageUnitTypeString(StorageUnitType type);
   void UpdateStorageList();
   static gboolean OnUpdateTimeout(gpointer user_data);


### PR DESCRIPTION
BUG=XWALK-2909

The old implementatin didn't check udev_device_get_sysattr_value(dev, "removable")'s
return value which will be NULL when dev hasn't removable attribute (This will happen
when dev is a partition of a device, not the device itself). When a NULL value
directly as std::stio's parameter, the crash will happen.

This change will check udev_device_get_sysattr_value's return vaule. Only when it's a
valid value, it can continue to do the next thing.
