### PR TITLE
Fix the inputKeyboardLayout type to bool

### DIFF
--- a/system_info/system_info_instance.cc
+++ b/system_info/system_info_instance.cc
@@ -197,7 +197,11 @@ void SystemInfoInstance::HandleGetCapabilities() {
   if (system_info_get_platform_string(
       "tizen.org/feature/input.keyboard.layout",
       &s) == SYSTEM_INFO_ERROR_NONE) {
-    o["inputKeyboardLayout"] = picojson::value(s);
+    std::string noneStr ("none");
+    if (s != NULL && noneStr.compare(s) != 0)
+        o["inputKeyboardLayout"] = picojson::value(true);
+    else
+        o["inputKeyboardLayout"] = picojson::value(false);
     free(s);
   }
 


### PR DESCRIPTION
According to the spec(https://developer.tizen.org/dev-guide/2.2.0/org.tizen.web.device.apireference/tizen/systeminfo.html#::SystemInfo::SystemInfoDeviceCapability) readonly attribute boolean inputKeyboardLayout, change the type to bool.
