### PR TITLE
Fix the language and country format

### DIFF
--- a/system_info/system_info_locale_tizen.cc
+++ b/system_info/system_info_locale_tizen.cc
@@ -101,6 +101,9 @@ bool SysInfoLocale::GetLanguage() {
     return false;
 
   language_ = std::string(language_info);
+  //language_info may be en_US.utf8
+  std::size_t found = language_.find_first_of(".");
+  language_ = language_.substr(0, found);
   free(language_info);
 
   return true;
@@ -113,6 +116,9 @@ bool SysInfoLocale::GetCountry() {
     return false;
 
   country_ = std::string(country_info);
+  //country_info may be en_US.utf8
+  std::size_t found = country_.find_first_of(".");
+  country_ = country_.substr(0, found);
   free(country_info);
 
   return true;


### PR DESCRIPTION
BUG = XWALK-2361

Testing that language_info is en_US.utf8, but (LANGUAGE)_(REGION) syntax is required on the spec(https://developer.tizen.org/dev-guide/2.2.0/org.tizen.web.device.apireference/tizen/systeminfo.html#::SystemInfo::SystemInfoLocale), so fix it.
