### PR TITLE
Fix the inputKeyboardLayout type to bool

### DIFF
--- a/system_info/system_info_instance.cc
+++ b/system_info/system_info_instance.cc
@@ -197,7 +197,7 @@ void SystemInfoInstance::HandleGetCapabilities() {
   if (system_info_get_platform_string(
       "tizen.org/feature/input.keyboard.layout",
       &s) == SYSTEM_INFO_ERROR_NONE) {
-    o["inputKeyboardLayout"] = picojson::value(s);
+    o["inputKeyboardLayout"] = picojson::value(s != NULL && s != "none");
     free(s);
   }
 


### PR DESCRIPTION
Switch the inputKeyboardLayout attribute from string type to bool type as the spec SystemInfo API(https://developer.tizen.org/dev-guide/2.2.0/org.tizen.web.device.apireference/tizen/systeminfo.html#::SystemInfo::SystemInfoDeviceCapability) required.
