### PR TITLE
Fix the inputKeyboardLayout type to bool

### DIFF
--- a/system_info/system_info_instance.cc
+++ b/system_info/system_info_instance.cc
@@ -197,10 +197,7 @@ void SystemInfoInstance::HandleGetCapabilities() {
   if (system_info_get_platform_string(
       "tizen.org/feature/input.keyboard.layout",
       &s) == SYSTEM_INFO_ERROR_NONE) {
-    if (s != NULL && s != "none")
-      o["inputKeyboardLayout"] = picojson::value(true);
-    else
-      o["inputKeyboardLayout"] = picojson::value(false);
+    o["inputKeyboardLayout"] = picojson::value(s != NULL && s != "none");
     free(s);
   }
 


### PR DESCRIPTION
Switch the type of inputKeyboardLayout attribute from string to bool as the spec SystemInfo API(https://developer.tizen.org/dev-guide/2.2.1/org.tizen.web.device.apireference/tizen/systeminfo.html#::SystemInfo::SystemInfoDeviceCapability) required.

BUG = XWALK-2409
