### PR TITLE
[Tizen] Fix error handling in system setting API

### DIFF
--- a/system_setting/system_setting_api.js
+++ b/system_setting/system_setting_api.js
@@ -19,10 +19,10 @@ extension.setMessageListener(function(message) {
     delete m._reply_id;
     delete m._error;
     delete _callbacks[_reply_id];
-    if (_error === 0) {
+    if (!_error) {
       handler[0](m._file);
     } else if (handler[1]) {
-      handler[1](new tizen.WebAPIError(_error));
+      handler[1](new tizen.WebAPIError(tizen.WebAPIException.UNKNOWN_ERR));
     }
     delete m._file;
   } else {

--- a/system_setting/system_setting_instance.cc
+++ b/system_setting/system_setting_instance.cc
@@ -37,7 +37,7 @@ void SystemSettingInstance::OnPropertyHandled(const char* reply_id,
   o["_reply_id"] = picojson::value(reply_id);
   if (value)
     o["_file"] = picojson::value(value);
-  o["_error"] = picojson::value(static_cast<double>(ret));
+  o["_error"] = picojson::value(ret != 0);
 
   picojson::value v(o);
   PostMessage(v.serialize().c_str());


### PR DESCRIPTION
This patch fixes error handling when system setting get/set
property fails.
