### PR TITLE
[Vehicle] Fix build failure on tizen

### DIFF
--- a/vehicle/vehicle.h
+++ b/vehicle/vehicle.h
@@ -16,20 +16,6 @@
 
 #include "common/picojson.h"
 
-namespace amb {
-
-template <>
-struct traits<GDBusConnection> {
-  struct delete_functor {
-    void operator()(GDBusConnection* p) const {
-      if (p != nullptr)
-        g_dbus_connection_close_sync(p, nullptr, nullptr);
-    }
-  };
-};
-
-}  // namespace amb
-
 namespace common {
 
 class Instance;


### PR DESCRIPTION
Fix the following build error on tizen.

vehicle/vehicle.h:22:8: error: redefinition of 'struct
amb::traits<_GDBusConnection>' struct traits<GDBusConnection>  

/usr/include/amb/superptr.hpp:64:8: error: previous definition
of 'struct amb::traits<_GDBusConnection>'
