### PR TITLE
[bluetooth] refactoring code

### DIFF
--- a/bluetooth/bluetooth_instance.cc
+++ b/bluetooth/bluetooth_instance.cc
@@ -5,6 +5,7 @@
 #include "bluetooth/bluetooth_instance.h"
 
 #include "common/picojson.h"
+#include "tizen/tizen.h"
 
 BluetoothInstance::BluetoothInstance() {
   PlatformInitialize();
@@ -85,11 +86,11 @@ void BluetoothInstance::OnDiscoveryStarted(GObject*, GAsyncResult* res) {
   o["cmd"] = picojson::value("");
   o["reply_id"] = picojson::value(discover_callback_id_);
 
-  int errorCode = 0;
+  int errorCode = NO_ERROR;
   if (!result) {
     g_printerr("Error discovering: %s\n", error->message);
     g_error_free(error);
-    errorCode = 1;
+    errorCode = UNKNOWN_ERR;
   }
 
   o["error"] = picojson::value(static_cast<double>(errorCode));
@@ -117,7 +118,7 @@ void BluetoothInstance::OnDiscoveryStopped(GObject* source, GAsyncResult* res) {
   o["cmd"] = picojson::value("");
   o["reply_id"] = picojson::value(stop_discovery_callback_id_);
   stop_discovery_callback_id_.clear();
-  o["error"] = picojson::value(static_cast<double>(0));
+  o["error"] = picojson::value(static_cast<double>(NO_ERROR));
   picojson::value v(o);
   InternalPostMessage(v);
 }
@@ -149,7 +150,7 @@ void BluetoothInstance::AdapterInfoToValue(picojson::value::object& o) {
   bool visible = (adapter_info_["Discoverable"] == "true") ? true : false;
   o["visible"] = picojson::value(visible);
 
-  o["error"] = picojson::value(static_cast<double>(0));
+  o["error"] = picojson::value(static_cast<double>(NO_ERROR));
 }
 
 void BluetoothInstance::AdapterSendGetDefaultAdapterReply() {

--- a/bluetooth/bluetooth_instance_bluez4.cc
+++ b/bluetooth/bluetooth_instance_bluez4.cc
@@ -6,18 +6,18 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
-
-// FIXME: C++0x removed support for typeof. bluetooth.h requires it, so until
-// bluetooth.h is fixed to use something future safe, use the GCC intrinsic
-// __typeof__ as replacement.
-#define typeof(x) __typeof__(x)
-
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/rfcomm.h>
 
 #include <list>
 
 #include "common/picojson.h"
+#include "tizen/tizen.h"
+
+// FIXME: C++0x removed support for typeof. bluetooth.h requires it, so until
+// bluetooth.h is fixed to use something future safe, use the GCC intrinsic
+// __typeof__ as replacement.
+#define typeof(x) __typeof__(x)
 
 namespace {
 
@@ -319,7 +319,7 @@ void BluetoothInstance::OnGotAdapterProperties(GObject*, GAsyncResult* res) {
 
     o["cmd"] = picojson::value("");
     o["reply_id"] = picojson::value(callbacks_map_["Powered"]);
-    o["error"] = picojson::value(static_cast<double>(0));
+    o["error"] = picojson::value(static_cast<double>(NO_ERROR));
 
     InternalPostMessage(picojson::value(o));
 
@@ -349,9 +349,9 @@ void BluetoothInstance::OnAdapterPropertySet(
     g_error_free(error);
     // No matter the error info here, BlueZ4's documentation says the only
     // error that can be raised here is org.bluez.Error.InvalidArguments.
-    o["error"] = picojson::value(static_cast<double>(1));
+    o["error"] = picojson::value(static_cast<double>(INVALID_VALUES_ERR));
   } else {
-    o["error"] = picojson::value(static_cast<double>(0));
+    o["error"] = picojson::value(static_cast<double>(NO_ERROR));
   }
 
   InternalPostMessage(picojson::value(o));
@@ -452,7 +452,7 @@ void BluetoothInstance::OnBluetoothServiceVanished(GDBusConnection* connection,
 
 void BluetoothInstance::AdapterSetPowered(const picojson::value& msg) {
   bool powered = msg.get("value").get<bool>();
-  int error = 0;
+  int error = NO_ERROR;
 
   OnAdapterPropertySetData* property_set_callback_data_ =
       new OnAdapterPropertySetData;
@@ -527,13 +527,13 @@ void BluetoothInstance::OnAdapterCreateBonding(GObject*, GAsyncResult* res) {
   picojson::value::object o;
   o["cmd"] = picojson::value("");
   o["reply_id"] = picojson::value(callbacks_map_["CreateBonding"]);
-  o["error"] = picojson::value(static_cast<double>(0));
+  o["error"] = picojson::value(static_cast<double>(NO_ERROR));
 
   if (!result) {
     g_printerr("\n\nError on creating adapter bonding: %s\n", error->message);
     g_error_free(error);
 
-    o["error"] = picojson::value(static_cast<double>(1));
+    o["error"] = picojson::value(static_cast<double>(UNKNOWN_ERR));
   } else {
     g_variant_unref(result);
   }
@@ -549,13 +549,13 @@ void BluetoothInstance::OnAdapterDestroyBonding(GObject*, GAsyncResult* res) {
   picojson::value::object o;
   o["cmd"] = picojson::value("");
   o["reply_id"] = picojson::value(callbacks_map_["DestroyBonding"]);
-  o["error"] = picojson::value(static_cast<double>(0));
+  o["error"] = picojson::value(static_cast<double>(NO_ERROR));
 
   if (!result) {
     g_printerr("\n\nError on destroying adapter bonding: %s\n", error->message);
     g_error_free(error);
 
-    o["error"] = picojson::value(static_cast<double>(2));
+    o["error"] = picojson::value(static_cast<double>(UNKNOWN_ERR));
   } else {
     g_variant_unref(result);
   }
@@ -576,7 +576,7 @@ void BluetoothInstance::OnFoundDevice(GObject*, GAsyncResult* res) {
 
     o["cmd"] = picojson::value("");
     o["reply_id"] = picojson::value(callbacks_map_["DestroyBonding"]);
-    o["error"] = picojson::value(static_cast<double>(1));
+    o["error"] = picojson::value(static_cast<double>(UNKNOWN_ERR));
 
     InternalPostMessage(picojson::value(o));
     callbacks_map_.erase("DestroyBonding");
@@ -808,7 +808,7 @@ void BluetoothInstance::OnServiceAddRecord(GObject* object, GAsyncResult* res) {
   o["reply_id"] = picojson::value(callbacks_map_["RFCOMMListen"]);
 
   if (!result) {
-    o["error"] = picojson::value(static_cast<double>(1));
+    o["error"] = picojson::value(static_cast<double>(UNKNOWN_ERR));
 
     close(pending_listen_socket_);
 
@@ -833,7 +833,7 @@ void BluetoothInstance::OnServiceAddRecord(GObject* object, GAsyncResult* res) {
 
     g_variant_get(result, "(u)", &handle);
 
-    o["error"] = picojson::value(static_cast<double>(0));
+    o["error"] = picojson::value(static_cast<double>(NO_ERROR));
     o["server_fd"] = picojson::value(static_cast<double>(sk));
     o["sdp_handle"] = picojson::value(static_cast<double>(handle));
     o["channel"] = picojson::value(static_cast<double>(rfcomm_get_channel(sk)));
@@ -972,7 +972,7 @@ void BluetoothInstance::HandleCloseSocket(const picojson::value& msg) {
   picojson::value::object o;
   o["cmd"] = picojson::value("");
   o["reply_id"] = msg.get("reply_id");
-  o["error"] = picojson::value(static_cast<double>(0));
+  o["error"] = picojson::value(static_cast<double>(NO_ERROR));
 
   picojson::value v(o);
   InternalPostMessage(v);
@@ -985,9 +985,9 @@ void BluetoothInstance::OnServiceRemoveRecord(
   picojson::value::object o;
 
   if (!result) {
-    o["error"] = picojson::value(static_cast<double>(1));
+    o["error"] = picojson::value(static_cast<double>(UNKNOWN_ERR));
   } else {
-    o["error"] = picojson::value(static_cast<double>(0));
+    o["error"] = picojson::value(static_cast<double>(NO_ERROR));
     g_variant_unref(result);
   }
 

--- a/bluetooth/bluetooth_instance_bluez5.cc
+++ b/bluetooth/bluetooth_instance_bluez5.cc
@@ -4,8 +4,6 @@
 
 #include "bluetooth/bluetooth_instance.h"
 
-#include "common/picojson.h"
-
 static void getPropertyValue(const char* key, GVariant* value,
     picojson::value::object& o) {
   if (!strcmp(key, "Class")) {

--- a/bluetooth/bluetooth_instance_capi.h
+++ b/bluetooth/bluetooth_instance_capi.h
@@ -18,24 +18,6 @@
 
 #define LOG_ERR(msg) std::cerr << "[Error] " << msg << std::endl
 
-// Macros interfacing with C code from Bluetooth API.
-#define CAPI(fnc)                                                              \
-  do {                                                                         \
-    int _er = (fnc);                                                           \
-    if (_er != BT_ERROR_NONE) {                                                \
-      LOG_ERR(#fnc " failed");                                                 \
-    }                                                                          \
-  } while (0)
-
-// same CAPI macro providing error code
-#define CAPI_ERR(fnc, _er)                                                     \
-  do {                                                                         \
-    _er = (fnc);                                                               \
-    if (_er != BT_ERROR_NONE) {                                                \
-      LOG_ERR(#fnc " failed");                                                 \
-    }                                                                          \
-  } while (0)
-
 namespace picojson {
 
 class value;
@@ -52,13 +34,11 @@ class BluetoothInstance : public common::Instance {
   virtual void HandleMessage(const char* msg);
   virtual void HandleSyncMessage(const char* msg);
 
-  void InitializeAdapter();
-  void UninitializeAdapter();
-
+  void HandleGetDefaultAdapter(const picojson::value& msg);
+  static gboolean GetDefaultAdapter(gpointer user_data);
+  void HandleSetAdapterProperty(const picojson::value& msg);
   void HandleDiscoverDevices(const picojson::value& msg);
   void HandleStopDiscovery(const picojson::value& msg);
-  void HandleGetDefaultAdapter(const picojson::value& msg);
-  void HandleSetAdapterProperty(const picojson::value& msg);
   void HandleCreateBonding(const picojson::value& msg);
   void HandleDestroyBonding(const picojson::value& msg);
   void HandleRFCOMMListen(const picojson::value& msg);
@@ -72,61 +52,54 @@ class BluetoothInstance : public common::Instance {
   void HandleDisconnectSource(const picojson::value& msg);
   void HandleSendHealthData(const picojson::value& msg);
 
-  void InternalPostMessage(picojson::value v);
-  void InternalSetSyncReply(picojson::value v);
-  void FlushPendingMessages();
-
-  static gboolean GetDefaultAdapter(gpointer user_data);
-
+  // Tizen CAPI callbacks.
   static void OnStateChanged(int result, bt_adapter_state_e adapter_state,
       void* user_data);
-
   static void OnNameChanged(char* name, void* user_data);
-
   static void OnVisibilityChanged(int result,
       bt_adapter_visibility_mode_e visibility_mode, void* user_data);
-
   static void OnDiscoveryStateChanged(int result,
       bt_adapter_device_discovery_state_e discovery_state,
       bt_adapter_device_discovery_info_s* discovery_info, void* user_data);
-
   static void OnBondCreated(int result, bt_device_info_s* device_info,
       void* user_data);
-
   static void OnBondDestroyed(int result, char* remote_address,
       void* user_data);
-
   static bool OnKnownBondedDevice(bt_device_info_s* device_info,
       void* user_data);
-
   static void OnSocketConnected(int result,
       bt_socket_connection_state_e connection_state,
       bt_socket_connection_s* connection, void* user_data);
-
   static void OnSocketHasData(bt_socket_received_data_s* data, void* user_data);
-
   static void OnHdpConnected(int result, const char* remote_address,
       const char* app_id, bt_hdp_channel_type_e type, unsigned int channel,
       void* user_data);
-
   static void OnHdpDisconnected(int result, const char* remote_address,
       unsigned int channel, void* user_data);
-
   static void OnHdpDataReceived(unsigned int channel, const char* data,
       unsigned int size, void* user_data);
 
-  // Map JS reply_id to a C API callback
-  std::map<std::string, std::string> callbacks_id_map_;
+  // Methods to send JSON messages to Javascript
+  void PostAsyncError(const std::string& reply_id, int error);
+  void PostAsyncReply(const std::string& cmd, int error);
+  void PostAsyncReply(const std::string& cmd, int error,
+      picojson::value::object& o);
+  void SendCmdToJs(const std::string& cmd, picojson::value::object& o);
+  void SendSyncError(int error);
+  void PostResult(const std::string& cmd, const std::string& reply_id,
+      int error);
+  void PostResult(const std::string& cmd, const std::string& reply_id,
+      int error, picojson::value::object& o);
+
+  // Methods to handle javascript reply ids in order to use them for async calls
+  bool IsJsReplyId(const std::string& cmd);
+  void StoreReplyId(const picojson::value& msg);
+  void RemoveReplyId(const std::string& cmd);
+  std::map<std::string, std::string> reply_id_map_;
 
   std::map<int, bool> socket_connected_map_;
 
-  typedef std::vector<picojson::value> MessageQueue;
-  MessageQueue queue_;
-
-  bool is_js_context_initialized_;
-  bool adapter_enabled_;
   bool get_default_adapter_;
-  bool stop_discovery_from_js_;
 };
 
 #endif  // BLUETOOTH_BLUETOOTH_INSTANCE_CAPI_H_


### PR DESCRIPTION
- Add CAPI() and CAPI_SYNC() macros :
  In order to handle Tizen CAPI in a generic way. If CAPI call returns
  an error, a JSON post message is directly sent back to JS.
  If CAPI call returns no error, reply id is stored in order to be
  reused to finalize the JS async call.
- All reply ids are stored in reply_id_map_ associated with the
  JSON message cmd.
- Add specific methods to send JSON messages to JS:
  - PostAsyncReply() method is used for JS async calls.
  - SendCmdToJs() method is used to independently update JS state.
    For instance it allows to update Bluetooth web API state
    when BlueZ is attacked externally to Tizen CAPI.
- Remove several useless variables/methods.

Also fix XWALK-2832 and XWALK-1334
