### PR TITLE
[bluetooth] keep BT state when calling getDefaultAdapter() API

### DIFF
--- a/src/bluetooth/bluetooth_instance_capi.h
+++ b/src/bluetooth/bluetooth_instance_capi.h
@@ -35,7 +35,6 @@ class BluetoothInstance : public common::Instance {
   virtual void HandleSyncMessage(const char* msg);
 
   void HandleGetDefaultAdapter(const picojson::value& msg);
-  static gboolean GetDefaultAdapter(gpointer user_data);
   void HandleSetAdapterProperty(const picojson::value& msg);
   void HandleDiscoverDevices(const picojson::value& msg);
   void HandleStopDiscovery(const picojson::value& msg);
@@ -99,7 +98,7 @@ class BluetoothInstance : public common::Instance {
 
   std::map<int, bool> socket_connected_map_;
 
-  bool get_default_adapter_;
+  bool are_bond_devices_known_;
 };
 
 #endif  // BLUETOOTH_BLUETOOTH_INSTANCE_CAPI_H_


### PR DESCRIPTION
Bluetooth-frwk has been adapted to allow getting adapter properties
even if bluetooth adapter is powered off.

So modify getDefaultAdapter() API logic in order to be synchronous.

Handle bonded devices in order to fill known_devices array in javascript
once bluetooth is enabled.

relates to TC-2024
