### PR TITLE
[SystemInfo] Fix the language and country syntax

### DIFF
--- a/src/system_info/system_info_locale.h
+++ b/src/system_info/system_info_locale.h
@@ -47,6 +47,10 @@ class SysInfoLocale : public SysInfoObject {
   static void OnCountryChanged(keynode_t* node, void* user_data);
   static void OnLanguageChanged(keynode_t* node, void* user_data);
   void Update();
+
+  std::string GetFirstSubstringByDot(const std::string& str) {
+    return str.substr(0, str.find_first_of("."));
+  }
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(SysInfoLocale);

--- a/src/system_info/system_info_locale_tizen.cc
+++ b/src/system_info/system_info_locale_tizen.cc
@@ -100,7 +100,7 @@ bool SysInfoLocale::GetLanguage() {
   if (!language_info)
     return false;
 
-  language_ = std::string(language_info);
+  language_ = GetFirstSubstringByDot(std::string(language_info));
   free(language_info);
 
   return true;
@@ -112,7 +112,7 @@ bool SysInfoLocale::GetCountry() {
   if (!country_info)
     return false;
 
-  country_ = std::string(country_info);
+  country_ = GetFirstSubstringByDot(std::string(country_info));
   free(country_info);
 
   return true;


### PR DESCRIPTION
The country_info and language_info is LANGUAGE_REGION.uft8 format on Tizen, but LANGUAGE_REGION syntax is required on the spec(https://developer.tizen.org/dev-guide/2.2.1/org.tizen.web.device.apireference/tizen/systeminfo.html#::SystemInfo::SystemInfoLocale) so fix it.

BUG=XWALK-2361
