### PR TITLE
[CallHistory] Fix of memory leak in callhistory/callhistory_mobile.cc

### DIFF
--- a/src/callhistory/callhistory_mobile.cc
+++ b/src/callhistory/callhistory_mobile.cc
@@ -792,6 +792,7 @@ int CallHistoryInstance::HandleRemoveBatch(const picojson::value& msg) {
           uidlist << id << ", ";
         #endif
       } else {
+        delete[] ids;
         return err;
       }
   }


### PR DESCRIPTION
In "HandleRemoveBatch" method we should delete the dynamically created array "ids" before returning from this method.
