### PR TITLE
[Bluetooth] Choose bluetooth depend on system avilable.

### DIFF
--- a/src/bluetooth/bluetooth.gyp
+++ b/src/bluetooth/bluetooth.gyp
@@ -11,7 +11,7 @@
           'gio-2.0',
           'bluez',
         ],
-        'bluetooth%': 'tizen_capi',
+        'bluetooth%': '<!(bash identify_bluetooth_type.sh)',
       },
       'includes': [
         '../common/pkg-config.gypi',

--- a/src/bluetooth/identify_bluetooth_type.sh
+++ b/src/bluetooth/identify_bluetooth_type.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pkg-config --exists capi-network-bluetooth && echo "tizen_capi" && exit 0
+
+bluez_ver=$(pkg-config --modversion bluez)
+[[ $bluez_ver =~ ^5.([[:digit:]]*)$ ]] && echo "bluez5" && exit 0
+[[ $bluez_ver =~ ^4.([[:digit:]]*)$ ]] && echo "bluez4" && exit 0
+
+echo "Unknown"
+exit 1


### PR DESCRIPTION
Curent bluetooth.gyp break desktop build because bluetooth% is hard
coded as tizen_capi.

Script identify_bluetooth_type.sh is added to return correct
bluetooth string depend on the exsit of pkgconfig(capi-network-bluetooth)
and version of pkgconfig(bluez).

BUG=None
