### PR TITLE
[SystemSetting] Fixed build issue on desktop.

### DIFF
--- a/src/system_setting/system_setting.gyp
+++ b/src/system_setting/system_setting.gyp
@@ -17,20 +17,22 @@
         'system_setting_locale.cc',
         'system_setting_locale.h',
       ],
+      'variables': {
+        'packages': [
+          'gio-2.0',
+        ]
+      },
+      'includes': [
+        '../common/pkg-config.gypi',
+      ],
       'conditions': [
         ['tizen == 1', {
-          'includes': [
-            '../common/pkg-config.gypi',
-          ],
           'variables': {
             'packages': [
               'capi-system-system-settings',
               'vconf',
             ]
           },
-          'includes': [
-            '../common/pkg-config.gypi',
-          ],
         }],
       ],
     },


### PR DESCRIPTION
gio-2.0 dependency is added implicitly by vconf, but vconf is available
on Tizen only. So we need add this dependency in general to fix the
desktop build issue.

BUG=None
