### PR TITLE
[Tizen] Fix wrongly passed variable to function in audiosystem

### DIFF
--- a/src/audiosystem/audiosystem_audio_group.cc
+++ b/src/audiosystem/audiosystem_audio_group.cc
@@ -50,7 +50,6 @@ void AudioGroup::UpdateInfo(
 
 picojson::value::object AudioGroup::ToJsonObject() const {
   picojson::value::object reply;
-  picojson::array array;
 
   reply["id"] = picojson::value(static_cast<double>(index_));
   reply["label"] = picojson::value(label_);

--- a/src/audiosystem/audiosystem_context.cc
+++ b/src/audiosystem/audiosystem_context.cc
@@ -179,8 +179,8 @@ bool AudioSystemContext::Disconnect() {
   audio_streams_.clear();
 
   is_ready_ = false;
-  main_output_mute_control_ = main_input_mute_control_ = PA_INVALID_INDEX;
-  main_output_mute_control_ = main_input_mute_control_ = PA_INVALID_INDEX;
+  main_input_mute_control_ = PA_INVALID_INDEX;
+  main_output_mute_control_ = PA_INVALID_INDEX;
   return true;
 }
 


### PR DESCRIPTION
js_reply variable was prepared, but instead of it js_message was
passed to PostMessage function. Some other nits were fixed.
