### PR TITLE
Fix handling g_dbus_proxy_call_sync

### DIFF
--- a/src/application/application.cc
+++ b/src/application/application.cc
@@ -90,6 +90,7 @@ picojson::value* Application::Exit() {
     g_error_free(error);
     return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
   }
+  g_variant_unref(result);
   return CreateResultMessage();
 }
 
@@ -108,6 +109,7 @@ picojson::value* Application::Hide() {
     g_error_free(error);
     return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
   }
+  g_variant_unref(result);
   return CreateResultMessage();
 }
 

--- a/src/web_setting/web_setting.cc
+++ b/src/web_setting/web_setting.cc
@@ -76,6 +76,7 @@ std::unique_ptr<picojson::value> WebSetting::RemoveAllCookies() {
     g_error_free(error);
     return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
   }
+  g_variant_unref(result);
   return CreateResultMessage();
 }
 
@@ -96,5 +97,6 @@ std::unique_ptr<picojson::value> WebSetting::SetUserAgentString(
     g_error_free(error);
     return CreateResultMessage(WebApiAPIErrors::UNKNOWN_ERR);
   }
+  g_variant_unref(result);
   return CreateResultMessage();
 }


### PR DESCRIPTION
This patch frees values returned by this function, what should be done
manually according to documentation
https://developer.gnome.org/gio/stable/GDBusProxy.html#g-dbus-proxy-call-sync