### PR TITLE
Fix handling g_dbus_proxy_new_for_bus_sync

### DIFF
--- a/src/system_setting/system_setting_locale.cc
+++ b/src/system_setting/system_setting_locale.cc
@@ -42,6 +42,8 @@ std::string getLocale() {
                                               NULL,
                                               &error);
 
+  g_object_unref(proxy);
+
   if (error)  {
     LOGGER_E("Error getting locale: " << error->message);
     g_error_free(error);


### PR DESCRIPTION
This patch frees values returned by this function, what should be done
manually according to documentation
https://developer.gnome.org/gio/stable/GDBusProxy.html#g-dbus-proxy-new-for-bus-sync