### PR TITLE
[Bluetooth] Fix for new bluetooth platform api.

### DIFF
--- a/src/bluetooth/bluetooth_instance_capi.cc
+++ b/src/bluetooth/bluetooth_instance_capi.cc
@@ -274,12 +274,6 @@ void BluetoothInstance::OnDiscoveryStateChanged(int result,
       obj->SendCmdToJs(kDeviceFound, o);
       break;
     }
-    case BT_ADAPTER_DEVICE_DISCOVERY_REMOVED: {
-      picojson::value::object o;
-      o["Address"] = picojson::value(discovery_info->remote_address);
-      obj->SendCmdToJs(kDeviceRemoved, o);
-      break;
-    }
     default:
       LOG_ERR("Unknown discovery state callback!");
       break;


### PR DESCRIPTION
'BT_ADAPTER_DEVICE_DISCOVERY_REMOVED' enum was removed in new BT api.

New bluetooth platform api will be submitted to tizen:common and other profiles. 
But, 'BT_ADAPTER_DEVICE_DISCOVERY_REMOVED' enum was removed in that api. 
This commit should be merged and submitted to avoid build-break.

https://review.tizen.org/gerrit/#/c/31318/
