### PR TITLE
Sensor header has changed for new sensor API

### DIFF
--- a/src/system_info/system_info_device_orientation.h
+++ b/src/system_info/system_info_device_orientation.h
@@ -6,7 +6,7 @@
 #define SYSTEM_INFO_SYSTEM_INFO_DEVICE_ORIENTATION_H_
 
 #if defined(TIZEN)
-#include <sensor.h>
+#include <sensor_internal.h>
 #include <vconf.h>
 #endif
 


### PR DESCRIPTION
Sensor header has changed from "sensor.h" to "sensor_internal.h"
This commit should be merged and submitted to avoid build-break.

https://review.tizen.org/gerrit/#/c/29547/