### PR TITLE
[Sensor] Remove unused <sensors.h> header

### DIFF
--- a/src/system_info/system_info_instance.cc
+++ b/src/system_info/system_info_instance.cc
@@ -23,7 +23,6 @@
 #include <stdlib.h>
 #if defined(TIZEN)
 #include <pkgmgr-info.h>
-#include <sensors.h>
 #include <system_info.h>
 #endif
 


### PR DESCRIPTION
<sensors.h> header was not used.
This commit should be merged and submitted to avoid build-break.