### PR TITLE
[build] Always use -std=c++0x for src/common components.

### DIFF
--- a/src/common/common.gypi
+++ b/src/common/common.gypi
@@ -86,9 +86,11 @@
       'XW_Extension_SyncMessage.h',
     ],
     'cflags': [
-      '-std=c++0x',
       '-fPIC',
       '-fvisibility=hidden',
+    ],
+    'cflags_cc': [
+      '-std=c++0x',
     ],
   },
 }


### PR DESCRIPTION
Some plugins disables -std=c++0x flag for compilation
of generated sources (mediaserver, media_renderer, speech).
This implies to src/common and prevents usage of C++11 features.
This patch separates src/common as a static_library target.

BUG=XWALK-3678