### PR TITLE
Fix xwalk BT extension for bluez5(Tizen common 3.0)

### DIFF
--- a/src/bluetooth/bluetooth_instance_bluez5.cc
+++ b/src/bluetooth/bluetooth_instance_bluez5.cc
@@ -179,9 +179,9 @@ void BluetoothInstance::PlatformInitialize() {
       "org.bluez",
       "/org/bluez/hci0",
       "org.bluez.Adapter1",
-      NULL, /* GCancellable */
+      all_pending_, /* GCancellable */
       OnAdapterProxyCreatedThunk,
-      this);
+      CancellableWrap(all_pending_, this));
 
   g_dbus_object_manager_client_new_for_bus(G_BUS_TYPE_SYSTEM,
       G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
@@ -190,9 +190,9 @@ void BluetoothInstance::PlatformInitialize() {
       NULL,
       NULL,
       NULL,
-      NULL,
+      all_pending_, /* GCancellable */
       OnManagerCreatedThunk,
-      this);
+      CancellableWrap(all_pending_, this));
 }
 
 void BluetoothInstance::HandleGetDefaultAdapter(

--- a/src/bluetooth/identify_bluetooth_type.sh
+++ b/src/bluetooth/identify_bluetooth_type.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-pkg-config --exists capi-network-bluetooth && echo "tizen_capi" && exit 0
-
 bluez_ver=$(pkg-config --modversion bluez)
 [[ $bluez_ver =~ ^5.([[:digit:]]*)$ ]] && echo "bluez5" && exit 0
 [[ $bluez_ver =~ ^4.([[:digit:]]*)$ ]] && echo "bluez4" && exit 0
+
+pkg-config --exists capi-network-bluetooth && echo "tizen_capi" && exit 0
 
 echo "Unknown"
 exit 1


### PR DESCRIPTION
During integration of xwalk on tizen 3.0, the BT adapter was not responding and crashes each time the adapter is powered on (after dbus replies)
After comparison with bluez4 porting, it seems there are missing callbacks.

How to test: On the Tizen device:
// Activate BT radio

> connmanctl enable bluetooth
> // bt_use is the only group to have BT policies (/etc/dbus-1/system.d/bluetooth.conf)
> usermod -A bt_use guest

Launch/deploy a Web application calling BT APIs for guest user. (e.g. Settings.wgt)
(expected:
Adapter should display name "BlueZ 5.19" and scanning should work.)
